### PR TITLE
Fix. add eslint rule (off react button has type)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,7 @@ module.exports = {
     "no-unused-vars": "warn",
     "import/no-extraneous-dependencies": "off",
     "react/prop-types": "off",
+    "react/button-has-type": "off",
     "react/jsx-props-no-spreading": "off",
     "react/self-closing-comp": "off",
     "react/react-in-jsx-scope": "off",


### PR DESCRIPTION
### [노션 칸반 - FE환경세팅](https://poised-moon-73b.notion.site/FrontEnd-4e3f9fe85d7c4300b5685bd4e4225c9f?pvs=4)

### description

공용 Button Component 생성중 eslint rule 충돌을 방지하기 위한 
`"react/button-has-type": "off",` 룰 추가

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

