### PR TITLE
Style. add key colors to theme

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
       env: {
         node: true,
       },
-      files: [".eslintrc.{js,cjs}", "/tailwind.config.js"],
+      files: [".eslintrc.{js,cjs}", "./tailwind.config.js"],
       parserOptions: {
         sourceType: "script",
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,17 @@
+/* eslint-disable prettier/prettier */
 /** @type {import("tailwindcss").Config} */
 module.exports = {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     colors: {
-      white: "#FFFFFF",
+      "white": "#FFFFFF",
       "black-bg": "#393939",
       "black-text": "#000000",
       "light-grey": "#F5F5F5",
-      grey: "#D9D9D9",
+      "grey": "#D9D9D9",
       "dark-grey": "#B1B1B1",
-      yellow: "#F4F0CD",
-      blue: "#5AA6FF",
+      "yellow": "#F4F0CD",
+      "blue": "#5AA6FF",
     },
   },
   plugins: [],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,17 @@
-/** @type {import('tailwindcss').Config} */
-export default {
+/** @type {import("tailwindcss").Config} */
+module.exports = {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
-  theme: {},
+  theme: {
+    colors: {
+      white: "#FFFFFF",
+      "black-bg": "#393939",
+      "black-text": "#000000",
+      "light-grey": "#F5F5F5",
+      grey: "#D9D9D9",
+      "dark-grey": "#B1B1B1",
+      yellow: "#F4F0CD",
+      blue: "#5AA6FF",
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
### [노션 칸반 - FrontEnd 환경세팅](https://www.notion.so/FrontEnd-4e3f9fe85d7c4300b5685bd4e4225c9f?pvs=4)

### description

목업을 기반으로 색상 팔레트를 tailwindcss config의 theme에 추가하였습니다.
### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.
