### PR TITLE
Feat. add logout button following onSuccess and onError logic

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,6 +2,7 @@ import Button from "./shared/Button";
 import RelationButton from "./HeaderItems/RelationButton";
 import DocHandlerButtons from "./HeaderItems/DocHandlerButtons";
 import SwitchViewButtons from "./HeaderItems/SwitchViewButtons";
+import LogoutButton from "./HeaderItems/LogoutButton";
 
 function Header() {
   return (
@@ -17,6 +18,7 @@ function Header() {
         <div>
           <h1>Page Name</h1>
         </div>
+        <LogoutButton />
       </div>
 
       <div className="flex flex-row justify-between">

--- a/src/components/HeaderItems/LogoutButton.jsx
+++ b/src/components/HeaderItems/LogoutButton.jsx
@@ -1,0 +1,31 @@
+import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+
+import fetchData from "../../utils/axios";
+
+import Button from "../shared/Button";
+
+function LogoutButton() {
+  const navigate = useNavigate();
+
+  async function handleGoogleLogout() {
+    await fetchData("POST", "/auth/logout");
+  }
+
+  const { mutate } = useMutation(handleGoogleLogout, {
+    onSuccess: () => {
+      navigate("/login");
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+  });
+
+  return (
+    <div className="flex w-20 justify-center">
+      <Button onClick={mutate}>logout</Button>
+    </div>
+  );
+}
+
+export default LogoutButton;

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -20,15 +20,14 @@ function Login() {
     await fetchData("POST", "/auth/login", userInfoObject);
   }
 
-  const { mutate, isError, isSuccess } = useMutation(handleGoogleLogin);
-
-  if (isSuccess) {
-    navigate("/dashboard");
-  }
-
-  if (isError) {
-    console.log("sending user to errorpage");
-  }
+  const { mutate } = useMutation(handleGoogleLogin, {
+    onSuccess: () => {
+      navigate("/dashboard");
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+  });
 
   return (
     <div className="flex flex-col justify-center items-center p-20">


### PR DESCRIPTION
### [노션 칸반 - [FE] 로그아웃](https://www.notion.so/FE-59a658b24d3344c3909a5efc50faf0e0?pvs=4)

### description

헤더 목업 상의 logout에 로그아웃 로직 구현 후 연결하는 작업.

7/22 (16:55)
- 다음 토의사항들이 반영되어있습니다.
1. HeaderItems내부에 Logoutbutton 컴포넌트를 작성하였습니다.
2. onSuccess, onError 방식을 반영하여 logout로직을 구현하였습니다.
3. login도 onSuccess, onError방식으로 수정하였습니다.
4. login 성공시 /dashboard로 라우팅되도록 하였습니다.
5. 이전 커밋에 있던 /dashboard/listview로 replace되는 로직을 삭제하고 새로 커밋하여 force push하였습니다.

확인, 피드백 부탁드립니다~!

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] assignee가 있습니다.