### PR TITLE
Feat. add dashboard

### DIFF
--- a/src/components/pages/Dashboard.jsx
+++ b/src/components/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ function Dashboard() {
         No Database yet.
       </h1>
       <Button
-        className="w-[250px] h-[30px] rounded-[5px] bg-black-bg text-white drop-shadow-md hover:bg-dark-grey"
+        className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"
         onClick={() => {
           setShowModal(!showModal);
         }}
@@ -26,7 +26,7 @@ function Dashboard() {
       </Button>
       {showModal &&
         createPortal(
-          <div className="fixed w-[150px] h-[150px] left-1/2 top-1/2 bg-opacity-50">
+          <div className="fixed w-[150px] h-[150px] border-2 top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2 bg-opacity-50">
             hi, I am modal.
           </div>,
           document.body,

--- a/src/components/pages/Dashboard.jsx
+++ b/src/components/pages/Dashboard.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createPortal } from "react-dom";
+
+import Button from "../shared/Button";
+
+function Dashboard() {
+  const [showModal, setShowModal] = useState(false);
+  const navigate = useNavigate();
+  const database = [];
+
+  return database.length ? (
+    navigate("/dashboard/listView")
+  ) : (
+    <div className="flex flex-col justify-center items-center h-full">
+      <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[3rem]">
+        No Database yet.
+      </h1>
+      <Button
+        className="w-[250px] h-[30px] rounded-[5px] bg-black-bg text-white drop-shadow-md hover:bg-dark-grey"
+        onClick={() => {
+          setShowModal(!showModal);
+        }}
+      >
+        Click here to get Started!
+      </Button>
+      {showModal &&
+        createPortal(
+          <div className="fixed w-[150px] h-[150px] left-1/2 top-1/2 bg-opacity-50">
+            hi, I am modal.
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
### [노션 칸반 - 초기 dashboard](https://poised-moon-73b.notion.site/FE-dashboard-082f4535d7cf474392cc39889b5ed657?pvs=4)

### description
1. 초기 생성한 database의 유무에 따라 listView로 렌더링 혹은 DB 생성을 위한 안내 페이지 구현 완료
2. Modal - createPortal 을 이용해 구현 예정이나, 아직 modal component 생성 전이기에 추후에 모달 컴포넌트 생성시 간단하게 갈아 끼울 수 있도록 틀만 만들어 놓았습니다! 

### concern

모달 표현의 경우, 컴포넌트 내부의 showModal 스테이트를 생성하여 버튼 클릭시에 해당 스테이트로 모달이 뜨게 구현 하였는데 이에 관하여 좀더 깔끔하거나 혹은 좋은 로직이 있을까요? 괜찮은 아이디어 있으시다면 말씀 부탁드려 봅니다! 


### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] assignee가 있습니다.
