### PR TITLE
Feat. add modal wrapper to accept any component to be showed as modal

### DIFF
--- a/src/components/shared/Modal.jsx
+++ b/src/components/shared/Modal.jsx
@@ -1,0 +1,27 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { createPortal } from "react-dom";
+import PropTypes from "prop-types";
+
+function Modal({ children, onClick }) {
+  return createPortal(
+    <div
+      className="fixed flex justify-center items-center left-0 right-0 top-0 bottom-0 bg-lght-gray bg-opacity-50 z-10"
+      onClick={onClick}
+    >
+      <div
+        className="flex justify-center items-center h-auto w-auto overflow-auto"
+        onClick={event => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+Modal.propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+export default Modal;


### PR DESCRIPTION
### [노션 칸반 - Modal](https://poised-moon-73b.notion.site/FE-Modal-Database-e6975ed8ce4d44f99eb163daaa4775bb?pvs=4)



### description
내부에 다양한 컴포넌트를 모달로서 갈아 끼울 수 있는 공용 Modal component를 생성 하였습니다. 
최대한 범용성을 생각해 많은 기능을 넣지는 않았으니, 구현단계에서 이점 참고 해주시고 
관련하여 수정 혹은 피드백 있으시다면 편하게 말씀 부탁 드리겠습니다!

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

