### PR TITLE
Feat. add new document modal

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -7,13 +7,15 @@ import Login from "../components/pages/Login";
 import Header from "../components/Header";
 import Dashboard from "../components/pages/Dashboard";
 import Sidebar from "../components/Sidebar";
-import CreateDBModal from "../components/Modals/CreateDBModal";
-import Modal from "../components/shared/Modal";
 
 function App() {
   const [user, setUser] = useState("");
+<<<<<<< HEAD
   const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
+=======
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+>>>>>>> b88207b (Refactor. move Modals to appropriate components)
 
   const { isLoading } = useQuery(["authStatus"], authUser, {
     retry: 1,
@@ -36,12 +38,9 @@ function App() {
     return <h1>Loading...</h1>;
   }
 
-  function toggleModal() {
-    setShowModal(!showModal);
-  }
-
   return (
     <div className="flex flex-col h-screen">
+<<<<<<< HEAD
       {user ? <Header /> : null}
       <div className="flex flex-1">
         {user ? <Sidebar user={user} toggleModal={toggleModal} /> : null}
@@ -52,13 +51,22 @@ function App() {
               path="/dashboard"
               element={<Dashboard user={user} toggleModal={toggleModal} />}
             />
+=======
+      <Header user={user} />
+      <div className="flex flex-1">
+        <Sidebar />
+        <div className="flex grow justify-center">
+          <Routes>
+            <Route
+              path="/login"
+              element={
+                <Login onSuccess={setUser} setIsLoggedIn={setIsLoggedIn} />
+              }
+            />
+            <Route path="/dashboard" element={<Dashboard user={user} />} />
+>>>>>>> b88207b (Refactor. move Modals to appropriate components)
             <Route path="/" element={<Navigate replace to="/login" />} />
           </Routes>
-          {showModal && (
-            <Modal onClick={toggleModal}>
-              <CreateDBModal user={user} toggleModal={toggleModal} />
-            </Modal>
-          )}
         </div>
       </div>
     </div>

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -10,12 +10,7 @@ import Sidebar from "../components/Sidebar";
 
 function App() {
   const [user, setUser] = useState("");
-<<<<<<< HEAD
-  const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
-=======
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
->>>>>>> b88207b (Refactor. move Modals to appropriate components)
 
   const { isLoading } = useQuery(["authStatus"], authUser, {
     retry: 1,
@@ -40,31 +35,13 @@ function App() {
 
   return (
     <div className="flex flex-col h-screen">
-<<<<<<< HEAD
-      {user ? <Header /> : null}
+      {user ? <Header user={user} clickHandleLogout={setUser} /> : null}
       <div className="flex flex-1">
-        {user ? <Sidebar user={user} toggleModal={toggleModal} /> : null}
+        {user ? <Sidebar user={user} /> : null}
         <div className="flex grow justify-center">
           <Routes>
             <Route path="/login" element={<Login setUser={setUser} />} />
-            <Route
-              path="/dashboard"
-              element={<Dashboard user={user} toggleModal={toggleModal} />}
-            />
-=======
-      <Header user={user} />
-      <div className="flex flex-1">
-        <Sidebar />
-        <div className="flex grow justify-center">
-          <Routes>
-            <Route
-              path="/login"
-              element={
-                <Login onSuccess={setUser} setIsLoggedIn={setIsLoggedIn} />
-              }
-            />
             <Route path="/dashboard" element={<Dashboard user={user} />} />
->>>>>>> b88207b (Refactor. move Modals to appropriate components)
             <Route path="/" element={<Navigate replace to="/login" />} />
           </Routes>
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,10 @@
+import PropTypes from "prop-types";
+
 import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({ clickHandleLogout }) {
+function Header({ user, clickHandleLogout }) {
   return (
     <div className="flex flex-col w-full h-min-[120px] bg-black-bg">
       <div className="flex flex-row justify-between items-center h-[50px] p-3 bg-black-bg">
@@ -22,5 +24,10 @@ function Header({ clickHandleLogout }) {
     </div>
   );
 }
+
+Header.propTypes = {
+  user: PropTypes.string.isRequired,
+  clickHandleLogout: PropTypes.func.isRequired,
+};
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -16,7 +16,7 @@ function Header({ clickHandleLogout }) {
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
-        <Toolbar />
+        <Toolbar user={user} />
         <SaveButton />
       </div>
     </div>

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,6 +1,12 @@
-import Button from "../shared/Button";
+import { useState } from "react";
+import PropTypes from "prop-types";
 
-function DocHandlerButtons() {
+import Button from "../shared/Button";
+import AddDocumentModal from "../Modals/AddDocumentModal";
+
+function DocHandlerButtons({ user }) {
+  const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
+
   return (
     <div className="flex items-center">
       <Button className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey">
@@ -12,14 +18,29 @@ function DocHandlerButtons() {
       <Button className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey">
         <img src="/assets/right_icon.svg" alt="right icon" />
       </Button>
-      <Button className="flex justify-center items-center w-8 h-8 mr-1 rounded-md bg-white hover:bg-yellow">
+      <Button
+        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md bg-white hover:bg-yellow"
+        onClick={() => {
+          setShowAddDocumentModal(true);
+        }}
+      >
         <img src="/assets/plus_icon.svg" alt="plus icon" />
       </Button>
       <Button className="flex justify-center items-center w-8 h-8 rounded-md bg-white hover:bg-yellow">
         <img src="/assets/minus_icon.svg" alt="minus icon" />
       </Button>
+      {showAddDocumentModal && (
+        <AddDocumentModal
+          user={user}
+          closeModal={() => setShowAddDocumentModal(false)}
+        />
+      )}
     </div>
   );
 }
+
+DocHandlerButtons.propTypes = {
+  user: PropTypes.string.isRequired,
+};
 
 export default DocHandlerButtons;

--- a/src/components/HeaderItems/LogoutButton.jsx
+++ b/src/components/HeaderItems/LogoutButton.jsx
@@ -1,3 +1,5 @@
+import PropTypes from "prop-types";
+
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 
@@ -33,5 +35,9 @@ function LogoutButton({ clickHandleLogout }) {
     </div>
   );
 }
+
+LogoutButton.propTypes = {
+  clickHandleLogout: PropTypes.func.isRequired,
+};
 
 export default LogoutButton;

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,15 +1,21 @@
+import PropTypes from "prop-types";
+
 import RelationButton from "./RelationButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
-function Toolbar() {
+function Toolbar({ user }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
       <RelationButton />
-      <DocHandlerButtons />
+      <DocHandlerButtons user={user} />
       <SwitchViewButtons />
     </div>
   );
 }
+
+Toolbar.propTypes = {
+  user: PropTypes.string.isRequired,
+};
 
 export default Toolbar;

--- a/src/components/Modals/AddDocumentListSection.jsx
+++ b/src/components/Modals/AddDocumentListSection.jsx
@@ -1,24 +1,24 @@
 import PropTypes from "prop-types";
 
+import ModalLabel from "./ModalLabel";
+import ModalInputArea from "./ModalInputArea";
+
 function AddDocumentListSection({ fields, updateFieldValue }) {
   return fields.map((element, index) => {
     return (
-      <div key={element.fields_id} className="flex">
-        <div className="w-[150px]">
-          <div className="flex justify-end items-center mb-5 p-1 px-3">
-            <span className="h-7"></span>
-            {element.name}
-          </div>
+      <div key={element.field_id} className="flex">
+        <div className="w-[130px]">
+          <ModalLabel value={element.name} />
         </div>
-        <div className="flex justify-center items-center">
-          <div className="mb-5 p-1 px-3 rounded-md ring-2 ring-grey">
+        <div className="flex justify-center items-center px-3">
+          <ModalInputArea>
             <div className="flex flex-row justify-center items-center">
-              <input
-                className="flex h-7 w-[200px] rounded-md text-center"
+              <textarea
+                className="flex h-7 w-[300px] rounded-md text-center"
                 onChange={event => updateFieldValue(index, event)}
               />
             </div>
-          </div>
+          </ModalInputArea>
         </div>
       </div>
     );
@@ -28,7 +28,7 @@ function AddDocumentListSection({ fields, updateFieldValue }) {
 AddDocumentListSection.propTypes = {
   fields: PropTypes.arrayOf(
     PropTypes.shape({
-      fields_id: PropTypes.string.isRequired,
+      field_id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
     }),
   ).isRequired,

--- a/src/components/Modals/AddDocumentListSection.jsx
+++ b/src/components/Modals/AddDocumentListSection.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+
+function AddDocumentListSection({ fields, updateFieldValue }) {
+  return fields.map((element, index) => {
+    return (
+      <div key={element.fields_id} className="flex">
+        <div className="w-[150px]">
+          <div className="flex justify-end items-center mb-5 p-1 px-3">
+            <span className="h-7"></span>
+            {element.name}
+          </div>
+        </div>
+        <div className="flex justify-center items-center">
+          <div className="mb-5 p-1 px-3 rounded-md ring-2 ring-grey">
+            <div className="flex flex-row justify-center items-center">
+              <input
+                className="flex h-7 w-[200px] rounded-md text-center"
+                onChange={event => updateFieldValue(index, event)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  });
+}
+
+AddDocumentListSection.propTypes = {
+  fields: PropTypes.arrayOf(
+    PropTypes.shape({
+      fields_id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  updateFieldValue: PropTypes.func,
+};
+
+export default AddDocumentListSection;

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -7,13 +7,14 @@ import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
 import Modal from "../shared/Modal";
+import ModalTitle from "./ModalTitle";
 import AddDocumentListSection from "./AddDocumentListSection";
 
 function AddDocumentModal({ user, closeModal }) {
   const navigate = useNavigate();
   const [fields, setFields] = useState([
     { field_id: "asdfb1jg", name: "악기 이름", value: "" },
-    { field_id: "asdfb2cd", name: "연습한 횟수", value: "" },
+    { field_id: "asdfb2cd", name: "연습 횟수", value: "" },
     { field_id: "asdfb2ad", name: "시작 시간", value: "" },
   ]);
 
@@ -31,7 +32,6 @@ function AddDocumentModal({ user, closeModal }) {
       fields,
     };
 
-    closeModal();
     await fetchData(
       "POST",
       `/users/${user}/databases/${databaseId}/documents`,
@@ -42,6 +42,7 @@ function AddDocumentModal({ user, closeModal }) {
   const { mutate } = useMutation(handleClickSave, {
     onSuccess: () => {
       navigate("/dashboard/listview");
+      closeModal();
     },
     onFailure: () => {
       console.log("sending user to errorpage");
@@ -51,7 +52,7 @@ function AddDocumentModal({ user, closeModal }) {
   return (
     <Modal onClick={closeModal}>
       <div className="flex flex-col items-center">
-        <h1 className="flex text-xl font-bold mb-5">Add New Document</h1>
+        <ModalTitle value="Add New Document" />
         <div className="flex flex-col justify-center items-center h-auto">
           <div className="flex">
             <div className="flex flex-col items-center p-3">

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
+
+import { useMutation } from "@tanstack/react-query";
+import fetchData from "../../utils/axios";
+
+import Button from "../shared/Button";
+import Modal from "../shared/Modal";
+import AddDocumentListSection from "./AddDocumentListSection";
+
+function AddDocumentModal({ user, closeModal }) {
+  const navigate = useNavigate();
+  const [fields, setFields] = useState([
+    { field_id: "asdfb1jg", name: "악기 이름", value: "" },
+    { field_id: "asdfb2cd", name: "연습한 횟수", value: "" },
+    { field_id: "asdfb2ad", name: "시작 시간", value: "" },
+  ]);
+
+  const databaseId = "abc";
+
+  function updateFieldValue(index, event) {
+    const newArr = [...fields];
+    newArr[index].value = event.target.value;
+
+    setFields(newArr);
+  }
+
+  async function handleClickSave() {
+    const newDatabase = {
+      fields,
+    };
+
+    closeModal();
+    await fetchData(
+      "POST",
+      `/users/${user}/databases/${databaseId}/documents`,
+      newDatabase,
+    );
+  }
+
+  const { mutate } = useMutation(handleClickSave, {
+    onSuccess: () => {
+      navigate("/dashboard/listview");
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+  });
+
+  return (
+    <Modal onClick={closeModal}>
+      <div className="flex flex-col items-center">
+        <h1 className="flex text-xl font-bold mb-5">Add New Document</h1>
+        <div className="flex flex-col justify-center items-center h-auto">
+          <div className="flex">
+            <div className="flex flex-col items-center p-3">
+              <AddDocumentListSection
+                fields={fields}
+                updateFieldValue={updateFieldValue}
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <Button
+            className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
+            onClick={mutate}
+          >
+            Submit
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+AddDocumentModal.propTypes = {
+  user: PropTypes.string.isRequired,
+  closeModal: PropTypes.func.isRequired,
+};
+
+export default AddDocumentModal;

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
-import { useMutation } from "@tanstack/react-query";
 import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
@@ -39,7 +39,7 @@ function AddDocumentModal({ user, closeModal }) {
     );
   }
 
-  const { mutate } = useMutation(handleClickSave, {
+  const { mutate: fetchDocumentSave } = useMutation(handleClickSave, {
     onSuccess: () => {
       navigate("/dashboard/listview");
       closeModal();
@@ -66,7 +66,7 @@ function AddDocumentModal({ user, closeModal }) {
         <div>
           <Button
             className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
-            onClick={mutate}
+            onClick={fetchDocumentSave}
           >
             Submit
           </Button>

--- a/src/components/Modals/CreateDBListSection.jsx
+++ b/src/components/Modals/CreateDBListSection.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 
 import Select from "../shared/Select";
 import Button from "../shared/Button";
+import ModalInputArea from "./ModalInputArea";
 
 import CONSTANT from "../../constants/constant";
 
@@ -15,28 +16,27 @@ function CreateDBListSection({
 }) {
   return fields.map((element, index) => {
     return (
-      <div
-        key={element.id}
-        className="mb-5 p-1 px-3 rounded-md ring-2 ring-grey"
-      >
-        <div className="flex flex-row justify-center items-center">
-          <input
-            className="flex h-7 w-full mr-3 rounded-md text-center"
-            maxLength={maxFieldNameLength}
-            value={element.name}
-            onChange={event => updateFieldName(index, event)}
-          />
-          <Select
-            options={fieldTypes}
-            onChange={event => updateFieldType(index, event)}
-          />
-          <Button
-            className="flex justify-center items-center"
-            onClick={() => handleClickDeleteField(index)}
-          >
-            <img className="w-10" src="/assets/bin_icon.svg" alt="bin icon" />
-          </Button>
-        </div>
+      <div key={element.id} className="mb-4">
+        <ModalInputArea>
+          <div className="flex flex-row justify-center items-center">
+            <input
+              className="flex h-7 w-full mr-3 rounded-md text-center"
+              maxLength={maxFieldNameLength}
+              value={element.name}
+              onChange={event => updateFieldName(index, event)}
+            />
+            <Select
+              options={fieldTypes}
+              onChange={event => updateFieldType(index, event)}
+            />
+            <Button
+              className="flex justify-center items-center"
+              onClick={() => handleClickDeleteField(index)}
+            >
+              <img className="w-10" src="/assets/bin_icon.svg" alt="bin icon" />
+            </Button>
+          </div>
+        </ModalInputArea>
       </div>
     );
   });

--- a/src/components/Modals/CreateDBListSection.jsx
+++ b/src/components/Modals/CreateDBListSection.jsx
@@ -7,7 +7,7 @@ import CONSTANT from "../../constants/constant";
 
 const { maxFieldNameLength, fieldTypes } = CONSTANT;
 
-function CreateFields({
+function CreateDBListSection({
   fields,
   updateFieldName,
   updateFieldType,
@@ -42,7 +42,7 @@ function CreateFields({
   });
 }
 
-CreateFields.propTypes = {
+CreateDBListSection.propTypes = {
   fields: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -54,4 +54,4 @@ CreateFields.propTypes = {
   handleClickDeleteField: PropTypes.func,
 };
 
-export default CreateFields;
+export default CreateDBListSection;

--- a/src/components/Modals/CreateDBModal.jsx
+++ b/src/components/Modals/CreateDBModal.jsx
@@ -8,6 +8,9 @@ import fetchData from "../../utils/axios";
 import Button from "../shared/Button";
 import Modal from "../shared/Modal";
 import CreateDBListSection from "./CreateDBListSection";
+import ModalTitle from "./ModalTitle";
+import ModalLabel from "./ModalLabel";
+import ModalInputArea from "./ModalInputArea";
 
 import CONSTANT from "../../constants/constant";
 
@@ -76,13 +79,13 @@ function CreateDBModal({ user, closeModal }) {
       fields,
     };
 
-    closeModal();
     await fetchData("POST", `/users/${user}/databases`, newDatabase);
   }
 
   const { mutate } = useMutation(handleClickSave, {
     onSuccess: () => {
       navigate("/dashboard/listview");
+      closeModal();
     },
     onFailure: () => {
       console.log("sending user to errorpage");
@@ -92,53 +95,50 @@ function CreateDBModal({ user, closeModal }) {
   return (
     <Modal onClick={closeModal}>
       <div className="flex flex-col items-center">
-        <h1 className="flex text-xl font-bold mb-5">Create New Database</h1>
+        <ModalTitle value="Create New Database" />
         <div className="flex justify-center">
-          <div className="flex flex-col items-end w-auto h-auto mr-3">
-            <div className="flex items-center h-16">
-              <span className="flex items-center">Database Name</span>
-            </div>
-            <div className="flex items-center h-16">
-              <span className="h-7">Fields Name</span>
-            </div>
+          <div className="flex flex-col w-auto h-auto">
+            <ModalLabel value="Database Name" />
+            <ModalLabel value="Fields Name" />
           </div>
           <div className="flex flex-col justify-center items-center h-auto">
-            <div className="flex justify-center items-center w-full h-16 p-3">
-              <div className="flex justify-center items-center w-full p-1 px-3 rounded-lg ring-2 ring-grey">
+            <div className="flex justify-center items-center w-full p-2">
+              <ModalInputArea>
                 <input
                   className="flex w-full h-7 rounded-lg text-center"
                   maxLength={maxDatabaseNameLength}
                   onChange={event => setdbName(event.target.value)}
                 />
-              </div>
+              </ModalInputArea>
             </div>
             <div className="flex">
-              <div className="flex flex-col items-center p-3">
-                <CreateDBListSection
-                  fields={fields}
-                  updateFieldName={updateFieldName}
-                  updateFieldType={updateFieldType}
-                  handleClickDeleteField={handleClickDeleteField}
-                />
-                <Button
-                  className="flex justify-center items-center w-full mb-5 p-1 px-3 rounded-lg ring-2 ring-grey"
-                  onClick={handleClickAddField}
-                >
-                  <div className="h-7"></div>
-                  <img src="assets/add_icon.svg" alt="add button" />
-                </Button>
+              <div className="flex flex-col items-center">
+                <div className="mb-5 p-2">
+                  <CreateDBListSection
+                    fields={fields}
+                    updateFieldName={updateFieldName}
+                    updateFieldType={updateFieldType}
+                    handleClickDeleteField={handleClickDeleteField}
+                  />
+                  <ModalInputArea>
+                    <Button
+                      className="flex justify-center items-center h-7 p-2"
+                      onClick={handleClickAddField}
+                    >
+                      <img src="assets/add_icon.svg" alt="add button" />
+                    </Button>
+                  </ModalInputArea>
+                </div>
               </div>
             </div>
           </div>
         </div>
-        <div>
-          <Button
-            className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
-            onClick={mutate}
-          >
-            Submit
-          </Button>
-        </div>
+        <Button
+          className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
+          onClick={mutate}
+        >
+          Submit
+        </Button>
       </div>
     </Modal>
   );

--- a/src/components/Modals/CreateDBModal.jsx
+++ b/src/components/Modals/CreateDBModal.jsx
@@ -6,13 +6,14 @@ import { useMutation } from "@tanstack/react-query";
 import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
-import CreateFields from "./CreateFields";
+import Modal from "../shared/Modal";
+import CreateDBListSection from "./CreateDBListSection";
 
 import CONSTANT from "../../constants/constant";
 
 const { maxDatabaseNameLength } = CONSTANT;
 
-function CreateDB({ user, toggleModal }) {
+function CreateDBModal({ user, closeModal }) {
   const navigate = useNavigate();
   const [dbName, setdbName] = useState(null);
   const [fields, setFields] = useState([
@@ -75,12 +76,12 @@ function CreateDB({ user, toggleModal }) {
       fields,
     };
 
+    closeModal();
     await fetchData("POST", `/users/${user}/databases`, newDatabase);
   }
 
   const { mutate } = useMutation(handleClickSave, {
     onSuccess: () => {
-      toggleModal();
       navigate("/dashboard/listview");
     },
     onFailure: () => {
@@ -89,61 +90,63 @@ function CreateDB({ user, toggleModal }) {
   });
 
   return (
-    <div className="flex flex-col items-center">
-      <h1 className="flex text-xl font-bold mb-5">Create New Database</h1>
-      <div className="flex justify-center">
-        <div className="flex flex-col items-end w-auto h-auto mr-3">
-          <div className="flex items-center h-16">
-            <span className="flex items-center">Database Name</span>
-          </div>
-          <div className="flex items-center h-16">
-            <span className="h-7">Fields Name</span>
-          </div>
-        </div>
-        <div className="flex flex-col justify-center items-center h-auto">
-          <div className="flex justify-center items-center w-full h-16 p-3">
-            <div className="flex justify-center items-center w-full p-1 px-3 rounded-lg ring-2 ring-grey">
-              <input
-                className="flex w-full h-7 rounded-lg text-center"
-                maxLength={maxDatabaseNameLength}
-                onChange={event => setdbName(event.target.value)}
-              />
+    <Modal onClick={closeModal}>
+      <div className="flex flex-col items-center">
+        <h1 className="flex text-xl font-bold mb-5">Create New Database</h1>
+        <div className="flex justify-center">
+          <div className="flex flex-col items-end w-auto h-auto mr-3">
+            <div className="flex items-center h-16">
+              <span className="flex items-center">Database Name</span>
+            </div>
+            <div className="flex items-center h-16">
+              <span className="h-7">Fields Name</span>
             </div>
           </div>
-          <div className="flex">
-            <div className="flex flex-col items-center p-3">
-              <CreateFields
-                fields={fields}
-                updateFieldName={updateFieldName}
-                updateFieldType={updateFieldType}
-                handleClickDeleteField={handleClickDeleteField}
-              />
-              <Button
-                className="flex justify-center items-center w-full mb-5 p-1 px-3 rounded-lg ring-2 ring-grey"
-                onClick={handleClickAddField}
-              >
-                <div className="h-7"></div>
-                <img src="/assets/add_icon.svg" alt="add icon" />
-              </Button>
+          <div className="flex flex-col justify-center items-center h-auto">
+            <div className="flex justify-center items-center w-full h-16 p-3">
+              <div className="flex justify-center items-center w-full p-1 px-3 rounded-lg ring-2 ring-grey">
+                <input
+                  className="flex w-full h-7 rounded-lg text-center"
+                  maxLength={maxDatabaseNameLength}
+                  onChange={event => setdbName(event.target.value)}
+                />
+              </div>
+            </div>
+            <div className="flex">
+              <div className="flex flex-col items-center p-3">
+                <CreateDBListSection
+                  fields={fields}
+                  updateFieldName={updateFieldName}
+                  updateFieldType={updateFieldType}
+                  handleClickDeleteField={handleClickDeleteField}
+                />
+                <Button
+                  className="flex justify-center items-center w-full mb-5 p-1 px-3 rounded-lg ring-2 ring-grey"
+                  onClick={handleClickAddField}
+                >
+                  <div className="h-7"></div>
+                  <img src="assets/add_icon.svg" alt="add button" />
+                </Button>
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <Button
+            className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
+            onClick={mutate}
+          >
+            Submit
+          </Button>
+        </div>
       </div>
-      <div>
-        <Button
-          className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
-          onClick={mutate}
-        >
-          Submit
-        </Button>
-      </div>
-    </div>
+    </Modal>
   );
 }
 
-CreateDB.propTypes = {
+CreateDBModal.propTypes = {
   user: PropTypes.string.isRequired,
-  toggleModal: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
 };
 
-export default CreateDB;
+export default CreateDBModal;

--- a/src/components/Modals/CreateDBModal.jsx
+++ b/src/components/Modals/CreateDBModal.jsx
@@ -82,7 +82,7 @@ function CreateDBModal({ user, closeModal }) {
     await fetchData("POST", `/users/${user}/databases`, newDatabase);
   }
 
-  const { mutate } = useMutation(handleClickSave, {
+  const { mutate: fetchDatabaseSave } = useMutation(handleClickSave, {
     onSuccess: () => {
       navigate("/dashboard/listview");
       closeModal();
@@ -135,7 +135,7 @@ function CreateDBModal({ user, closeModal }) {
         </div>
         <Button
           className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
-          onClick={mutate}
+          onClick={fetchDatabaseSave}
         >
           Submit
         </Button>

--- a/src/components/Modals/ModalInputArea.jsx
+++ b/src/components/Modals/ModalInputArea.jsx
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+function ModalInputArea({ children }) {
+  return (
+    <div className="flex justify-center items-center w-full p-1 px-3 rounded-lg ring-2 ring-grey">
+      {children}
+    </div>
+  );
+}
+
+ModalInputArea.propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+export default ModalInputArea;

--- a/src/components/Modals/ModalLabel.jsx
+++ b/src/components/Modals/ModalLabel.jsx
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+
+function ModalLabel({ value }) {
+  return (
+    <div className="flex justify-end p-3">
+      <span className="flex items-center h-7">{value}</span>
+    </div>
+  );
+}
+
+ModalLabel.propTypes = {
+  value: PropTypes.string.isRequired,
+};
+
+export default ModalLabel;

--- a/src/components/Modals/ModalTitle.jsx
+++ b/src/components/Modals/ModalTitle.jsx
@@ -1,0 +1,11 @@
+import PropTypes from "prop-types";
+
+function ModalTitle({ value }) {
+  return <h1 className="flex text-xl font-bold mb-5">{value}</h1>;
+}
+
+ModalTitle.propTypes = {
+  value: PropTypes.string.isRequired,
+};
+
+export default ModalTitle;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,11 +1,15 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import fetchData from "../utils/axios";
 
 import Button from "./shared/Button";
+import CreateDBModal from "./Modals/CreateDBModal";
 
-function Sidebar({ user, toggleModal }) {
+function Sidebar({ user }) {
+  const [showCreateDBModal, setShowCreateDBModal] = useState(false);
+
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${user}/databases`);
 
@@ -59,7 +63,7 @@ function Sidebar({ user, toggleModal }) {
       <div className="flex justify-center">
         <Button
           className="flex justify-center w-48 text-sm items-center rounded-full text-white bg-black-bg hover:bg-dark-grey"
-          onClick={toggleModal}
+          onClick={() => setShowCreateDBModal(true)}
         >
           <img
             className="flex justify-between items-center mr-2 w-4"
@@ -69,6 +73,12 @@ function Sidebar({ user, toggleModal }) {
           New Database
         </Button>
       </div>
+      {showCreateDBModal && (
+        <CreateDBModal
+          user={user}
+          closeModal={() => setShowCreateDBModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/pages/Dashboard.jsx
+++ b/src/components/pages/Dashboard.jsx
@@ -19,7 +19,7 @@ function Dashboard({ user }) {
         No Database yet.
       </h1>
       <Button
-        className="w-[250px] h-[30px] rounded-full bg-black-bg text-white hover:bg-dark-grey"
+        className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"
         onClick={() => {
           setShowCreateDBModal(true);
         }}

--- a/src/components/pages/Dashboard.jsx
+++ b/src/components/pages/Dashboard.jsx
@@ -1,12 +1,15 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
 
 import { useNavigate } from "react-router-dom";
 
 import Button from "../shared/Button";
+import CreateDBModal from "../Modals/CreateDBModal";
 
-function Dashboard({ toggleModal }) {
+function Dashboard({ user }) {
   const navigate = useNavigate();
   const database = [];
+  const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return database.length ? (
     navigate("/dashboard/listView")
@@ -18,17 +21,23 @@ function Dashboard({ toggleModal }) {
       <Button
         className="w-[250px] h-[30px] rounded-full bg-black-bg text-white hover:bg-dark-grey"
         onClick={() => {
-          toggleModal();
+          setShowCreateDBModal(true);
         }}
       >
         Click here to get Started!
       </Button>
+      {showCreateDBModal && (
+        <CreateDBModal
+          user={user}
+          closeModal={() => setShowCreateDBModal(false)}
+        />
+      )}
     </div>
   );
 }
 
 Dashboard.propTypes = {
-  toggleModal: PropTypes.func.isRequired,
+  user: PropTypes.string.isRequired,
 };
 
 export default Dashboard;


### PR DESCRIPTION
### [[FE] Modal - Document 생성](https://www.notion.so/FE-Modal-Document-7fb57dd8577840b9a2faf52a76a8eac1?pvs=4)

### description

- add new document 모달창 구현
- 각각 create DB와 add doc 모달을 상위 컴포넌트에서 하위 컴포넌트로 옮겨주었습니다.
user prop외에 drilling해주는 값이 없어 훨씬 간결하고 관심사에 따라 모달의 위치를 파악하기가 쉬워졌습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

![Jul-25-2023 00-53-25](https://github.com/Team-Dataface/DataFace-client/assets/83858724/c874c6dd-b5b6-44d4-aa8e-c4286abdf0c8)


