### PR TITLE
Feat. send current DB state to App and apply bg-color to chosen one

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -10,6 +10,7 @@ import Sidebar from "../components/Sidebar";
 
 function App() {
   const [user, setUser] = useState("");
+  const [currentDBId, setCurrentDBId] = useState("");
   const navigate = useNavigate();
 
   const { isLoading } = useQuery(["authStatus"], authUser, {
@@ -35,9 +36,21 @@ function App() {
 
   return (
     <div className="flex flex-col h-screen">
-      {user ? <Header user={user} clickHandleLogout={setUser} /> : null}
+      {user ? (
+        <Header
+          user={user}
+          clickHandleLogout={setUser}
+          currentDBId={currentDBId}
+        />
+      ) : null}
       <div className="flex flex-1">
-        {user ? <Sidebar user={user} /> : null}
+        {user ? (
+          <Sidebar
+            user={user}
+            currentDBId={currentDBId}
+            setCurrentDBId={setCurrentDBId}
+          />
+        ) : null}
         <div className="flex grow justify-center">
           <Routes>
             <Route path="/login" element={<Login setUser={setUser} />} />

--- a/src/components/Modals/CreateDBModal.jsx
+++ b/src/components/Modals/CreateDBModal.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
@@ -17,6 +17,7 @@ import CONSTANT from "../../constants/constant";
 const { maxDatabaseNameLength } = CONSTANT;
 
 function CreateDBModal({ user, closeModal }) {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [dbName, setdbName] = useState(null);
   const [fields, setFields] = useState([
@@ -84,6 +85,7 @@ function CreateDBModal({ user, closeModal }) {
 
   const { mutate: fetchDatabaseSave } = useMutation(handleClickSave, {
     onSuccess: () => {
+      queryClient.refetchQueries(["userDbList"]);
       navigate("/dashboard/listview");
       closeModal();
     },

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import PropTypes from "prop-types";
 import fetchData from "../utils/axios";
@@ -7,14 +7,23 @@ import fetchData from "../utils/axios";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateDBModal";
 
-function Sidebar({ user }) {
+function Sidebar({ user, currentDBId, setCurrentDBId }) {
+  const queryClient = useQueryClient();
+  const [firstDatabaseId, setFirstDatabaseId] = useState("");
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
+
+  useEffect(() => {
+    setCurrentDBId(firstDatabaseId);
+  }, [firstDatabaseId]);
 
   async function deleteDatabase(databaseId) {
     await fetchData("DELETE", `/users/${user}/databases/${databaseId}`);
   }
 
   const { mutate: fetchDeleteDB } = useMutation(deleteDatabase, {
+    onSuccess: () => {
+      queryClient.refetchQueries(["userDbList"]);
+    },
     onFailure: () => {
       console.log("sending user to errorpage");
     },
@@ -28,6 +37,9 @@ function Sidebar({ user }) {
 
   const { data, isLoading } = useQuery(["userDbList"], getDatabaseList, {
     enabled: !!user,
+    onSuccess: () => {
+      setFirstDatabaseId(data.data.databases[0]._id);
+    },
     onFailure: () => {
       console.log("sending user to errorpage");
     },
@@ -38,13 +50,27 @@ function Sidebar({ user }) {
   }
 
   function renderDatabaseList() {
+    function isActive(id) {
+      if (currentDBId === id) {
+        return true;
+      }
+
+      return false;
+    }
+
     return data.data.databases.map(element => {
       return (
         <div
           key={element._id}
-          className="flex justify-between items-center w-full hover:bg-grey active:bg-yellow"
+          className={`
+            flex justify-between items-center w-full hover:bg-grey
+            ${isActive(element._id) ? "bg-yellow" : ""}
+            `}
         >
-          <Button className="w-full">
+          <Button
+            className="w-full"
+            onClick={() => setCurrentDBId(element._id)}
+          >
             <div className="flex">
               <img
                 className="ml-6 mr-2"
@@ -96,6 +122,7 @@ function Sidebar({ user }) {
 
 Sidebar.propTypes = {
   user: PropTypes.string.isRequired,
+  setCurrentDBId: PropTypes.func.isRequired,
 };
 
 export default Sidebar;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import PropTypes from "prop-types";
@@ -9,12 +9,7 @@ import CreateDBModal from "./Modals/CreateDBModal";
 
 function Sidebar({ user, currentDBId, setCurrentDBId }) {
   const queryClient = useQueryClient();
-  const [firstDatabaseId, setFirstDatabaseId] = useState("");
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
-
-  useEffect(() => {
-    setCurrentDBId(firstDatabaseId);
-  }, [firstDatabaseId]);
 
   async function deleteDatabase(databaseId) {
     await fetchData("DELETE", `/users/${user}/databases/${databaseId}`);
@@ -37,12 +32,10 @@ function Sidebar({ user, currentDBId, setCurrentDBId }) {
 
   const { data, isLoading } = useQuery(["userDbList"], getDatabaseList, {
     enabled: !!user,
-    onSuccess: () => {
-      setFirstDatabaseId(data.data.databases[0]._id);
+    onSuccess: result => {
+      setCurrentDBId(result.data.databases[0]._id);
     },
-    onFailure: () => {
-      console.log("sending user to errorpage");
-    },
+    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -35,6 +35,9 @@ function Sidebar({ user, currentDBId, setCurrentDBId }) {
     onSuccess: result => {
       setCurrentDBId(result.data.databases[0]._id);
     },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
### [[FE] 좌측 사이드바](https://www.notion.so/FE-63ee0bf80da446c1bb50f1cddf1243ff?pvs=4)

### description

- 사이드바 로드시 첫번째 db이 자동선택되도록 database의 [0]번째 인덱스를 App의 state로 올립니다.
- 다른 DB 이름을 눌렀을 시 그 DB의 id를 App의 state로 올려 replace해줍니다.
앱 내부 state모습:
const [currentDBId, setCurrentDBId] = useState("");

currentDBId state를 작업하실 컴포넌트에 내려주어 useQuery를 통해 캐시에 필요 정보를 요청하면 됩니다~!
-  조건부 동적 className설정을 통해서 현재 보고있는 DB와 일치할 경우 노란 배경색이 들어옵니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

![Jul-25-2023 23-23-13](https://github.com/Team-Dataface/DataFace-client/assets/83858724/9e417df2-e297-4ded-86f3-b700ac980e3b)

