### PR TITLE
Feat. add document modal fetch function to DB

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({ user, clickHandleLogout }) {
+function Header({ user, clickHandleLogout, currentDBId }) {
   return (
     <div className="flex flex-col w-full h-min-[120px] bg-black-bg">
       <div className="flex flex-row justify-between items-center h-[50px] p-3 bg-black-bg">
@@ -18,7 +18,7 @@ function Header({ user, clickHandleLogout }) {
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
-        <Toolbar user={user} />
+        <Toolbar user={user} currentDBId={currentDBId} />
         <SaveButton />
       </div>
     </div>
@@ -28,6 +28,7 @@ function Header({ user, clickHandleLogout }) {
 Header.propTypes = {
   user: PropTypes.string.isRequired,
   clickHandleLogout: PropTypes.func.isRequired,
+  currentDBId: PropTypes.string.isRequired,
 };
 
 export default Header;

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Button from "../shared/Button";
 import AddDocumentModal from "../Modals/AddDocumentModal";
 
-function DocHandlerButtons({ user }) {
+function DocHandlerButtons({ user, currentDBId }) {
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
 
   return (
@@ -33,6 +33,7 @@ function DocHandlerButtons({ user }) {
         <AddDocumentModal
           user={user}
           closeModal={() => setShowAddDocumentModal(false)}
+          currentDBId={currentDBId}
         />
       )}
     </div>

--- a/src/components/HeaderItems/LogoutButton.jsx
+++ b/src/components/HeaderItems/LogoutButton.jsx
@@ -1,13 +1,13 @@
-import PropTypes from "prop-types";
-
 import { useNavigate } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
 
 function LogoutButton({ clickHandleLogout }) {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   async function handleGoogleLogout() {
@@ -17,6 +17,7 @@ function LogoutButton({ clickHandleLogout }) {
   const { mutate } = useMutation(handleGoogleLogout, {
     onSuccess: () => {
       clickHandleLogout("");
+      queryClient.clear();
       navigate("/login");
     },
     onFailure: () => {

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -4,11 +4,11 @@ import RelationButton from "./RelationButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
-function Toolbar({ user }) {
+function Toolbar({ user, currentDBId }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
       <RelationButton />
-      <DocHandlerButtons user={user} />
+      <DocHandlerButtons user={user} currentDBId={currentDBId} />
       <SwitchViewButtons />
     </div>
   );
@@ -16,6 +16,7 @@ function Toolbar({ user }) {
 
 Toolbar.propTypes = {
   user: PropTypes.string.isRequired,
+  currentDBId: PropTypes.string.isRequired,
 };
 
 export default Toolbar;

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -48,17 +48,19 @@ function AddDocumentModal({ user, closeModal, currentDBId }) {
     return response;
   }
 
-  const { data, isLoading } = useQuery(["userDb"], getDatabase, {
+  const { isLoading } = useQuery(["userDb"], getDatabase, {
     enabled: !!user,
-    onSuccess: () => {
+    onSuccess: result => {
       const newArr = [];
-      data.data.database.fields.map(element => {
+
+      result.data.database.fields.map(element => {
         return newArr.push({
           field_id: element._id,
           name: element.name,
           value: "",
         });
       });
+
       setFields(newArr);
     },
     onFailure: () => {
@@ -68,7 +70,7 @@ function AddDocumentModal({ user, closeModal, currentDBId }) {
   });
 
   if (isLoading) {
-    return <h1>querying userDb... LOADING</h1>;
+    return <h1>LOADING</h1>;
   }
 
   return (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -54,6 +54,11 @@ function Sidebar({ user, currentDBId, setCurrentDBId }) {
       return false;
     }
 
+    function switchDatabase(clickedDatabaseId) {
+      setCurrentDBId(clickedDatabaseId);
+      queryClient.refetchQueries(["userDb"]);
+    }
+
     return data.data.databases.map(element => {
       return (
         <div
@@ -65,7 +70,7 @@ function Sidebar({ user, currentDBId, setCurrentDBId }) {
         >
           <Button
             className="w-full"
-            onClick={() => setCurrentDBId(element._id)}
+            onClick={() => switchDatabase(element._id)}
           >
             <div className="flex">
               <img


### PR DESCRIPTION
### [노션 칸반 - Modal - Document 생성](https://www.notion.so/FE-Modal-Document-7fb57dd8577840b9a2faf52a76a8eac1?pvs=4)

### description

- 목업 데이터가 아닌 실제 data 생성하여, server에 fetch하는 데까지 완성하였습니다.
- fetch 타이밍 최적화가 있었습니다. sidebar에서 db 클릭 이벤트가 있는 경우 단순히 setCurrentDbId를 할 뿐 아니라,
userDb를 다시 GET해오도록 변경이 있습니다.


### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.


![Jul-26-2023 15-45-17](https://github.com/Team-Dataface/DataFace-client/assets/83858724/35a10497-fbc5-46fd-9f23-9d74a2f57f9c)