### PR TITLE
Feat. detail view with header functions

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -6,6 +6,7 @@ import authUser from "../utils/authUser";
 import Login from "../components/Login";
 import Header from "../components/Header";
 import ContentsContainer from "../components/ContentsContainer";
+import DetailView from "../components/contents/DetailView";
 import Sidebar from "../components/Sidebar";
 import ListView from "../components/contents/ListView";
 import NoDatabase from "../components/contents/NoDatabase";
@@ -15,6 +16,9 @@ import CONSTANT from "../constants/constant";
 function App() {
   const [user, setUser] = useState("");
   const [currentDBId, setCurrentDBId] = useState("");
+  const [currentDocIndex, setCurrentDocIndex] = useState(0);
+  const [documentsIds, setDocumentsIds] = useState([]);
+  const [isEditMode, setIsEditMode] = useState(false);
   const navigate = useNavigate();
 
   const { isLoading } = useQuery(["authStatus"], authUser, {
@@ -34,6 +38,7 @@ function App() {
       return navigate("/login");
     },
     staleTime: CONSTANT.oneHourInMillisecond,
+    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {
@@ -47,6 +52,10 @@ function App() {
           user={user}
           clickHandleLogout={setUser}
           currentDBId={currentDBId}
+          isEditMode={isEditMode}
+          onClickSave={setIsEditMode}
+          currentDocIndex={currentDocIndex}
+          clickHandleNavigator={setCurrentDocIndex}
         />
       ) : null}
       <div className="flex flex-1">
@@ -55,6 +64,7 @@ function App() {
             user={user}
             currentDBId={currentDBId}
             setCurrentDBId={setCurrentDBId}
+            setDocumentsIds={setDocumentsIds}
           />
         ) : null}
         <div className="flex grow justify-center">
@@ -66,7 +76,31 @@ function App() {
             >
               <Route
                 path="listview"
-                element={<ListView user={user} currentDBId={currentDBId} />}
+                element={
+                  <ListView
+                    user={user}
+                    currentDBId={currentDBId}
+                    isEditMode={isEditMode}
+                    setIsSaveMode={setIsEditMode}
+                    currentDocIndex={currentDocIndex}
+                    setCurrentDocIndex={setCurrentDocIndex}
+                    setDocumentsIds={setDocumentsIds}
+                  />
+                }
+              />
+              <Route
+                path="detailview"
+                element={
+                  <DetailView
+                    user={user}
+                    currentDBId={currentDBId}
+                    isEditMode={isEditMode}
+                    setIsEditMode={setIsEditMode}
+                    currentDocIndex={currentDocIndex}
+                    setCurrentDocIndex={setCurrentDocIndex}
+                    documentsIds={documentsIds}
+                  />
+                }
               />
               <Route
                 path="nodatabase"

--- a/src/components/ContentsContainer.jsx
+++ b/src/components/ContentsContainer.jsx
@@ -28,6 +28,7 @@ function ContentsContainer({ user }) {
     onFailure: () => {
       console.log("sending user to errorpage");
     },
+    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,10 +1,19 @@
+import { useState } from "react";
 import PropTypes from "prop-types";
 
 import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({ user, clickHandleLogout, currentDBId }) {
+function Header({
+  user,
+  clickHandleLogout,
+  currentDBId,
+  isEditMode,
+  onClickSave,
+  currentDocIndex,
+  clickHandleNavigator,
+}) {
   return (
     <div className="flex flex-col w-full h-min-[120px] bg-black-bg">
       <div className="flex flex-row justify-between items-center h-[50px] p-3 bg-black-bg">
@@ -18,8 +27,13 @@ function Header({ user, clickHandleLogout, currentDBId }) {
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
-        <Toolbar user={user} currentDBId={currentDBId} />
-        <SaveButton />
+        <Toolbar
+          user={user}
+          currentDBId={currentDBId}
+          currentDocIndex={currentDocIndex}
+          clickHandleNavigator={clickHandleNavigator}
+        />
+        <SaveButton isEditMode={isEditMode} onClickSave={onClickSave} />
       </div>
     </div>
   );
@@ -29,6 +43,10 @@ Header.propTypes = {
   user: PropTypes.string.isRequired,
   clickHandleLogout: PropTypes.func.isRequired,
   currentDBId: PropTypes.string.isRequired,
+  isEditMode: PropTypes.bool.isRequired,
+  onClickSave: PropTypes.func.isRequired,
+  currentDocIndex: PropTypes.number.isRequired,
+  clickHandleNavigator: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
@@ -18,13 +18,13 @@ function DocHandlerButtons({
 
   const currentDocIndexShownToUser = currentDocIndex + 1;
 
-  function navigateDownTilZero() {
+  function navigateDown() {
     if (currentDocIndexShownToUser !== 1) {
       clickHandleNavigator(prev => prev - 1);
     }
   }
 
-  function navigateDownTilMaxNum() {
+  function navigateUp() {
     if (currentDocIndexShownToUser !== documentsNum) {
       clickHandleNavigator(prev => prev + 1);
     }
@@ -58,7 +58,7 @@ function DocHandlerButtons({
     <div className="flex items-center">
       <Button
         className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
-        onClick={() => navigateDownTilZero()}
+        onClick={() => navigateDown()}
       >
         <img src="/assets/left_icon.svg" alt="left icon" />
       </Button>
@@ -67,7 +67,7 @@ function DocHandlerButtons({
       </span>
       <Button
         className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
-        onClick={() => navigateDownTilMaxNum()}
+        onClick={() => navigateUp()}
       >
         <img src="/assets/right_icon.svg" alt="right icon" />
       </Button>

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,21 +1,74 @@
 import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import PropTypes from "prop-types";
+
+import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
 import AddDocumentModal from "../Modals/AddDocumentModal";
 
-function DocHandlerButtons({ user, currentDBId }) {
+function DocHandlerButtons({
+  user,
+  currentDBId,
+  currentDocIndex,
+  clickHandleNavigator,
+}) {
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
+  const [documentsNum, setDocumentsNum] = useState(0);
+
+  const currentDocIndexShownToUser = currentDocIndex + 1;
+
+  function navigateDownTilZero() {
+    if (currentDocIndexShownToUser !== 1) {
+      clickHandleNavigator(prev => prev - 1);
+    }
+  }
+
+  function navigateDownTilMaxNum() {
+    if (currentDocIndexShownToUser !== documentsNum) {
+      clickHandleNavigator(prev => prev + 1);
+    }
+  }
+
+  async function getDocumentsList() {
+    const response = await fetchData(
+      "GET",
+      `users/${user}/databases/${currentDBId}`,
+    );
+
+    return response;
+  }
+
+  const { isLoading } = useQuery(["dbDocumentList"], getDocumentsList, {
+    enabled: !!user && !!currentDBId,
+    onSuccess: result => {
+      setDocumentsNum(result.data.database.documents.length);
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) {
+    return <h1>loading</h1>;
+  }
 
   return (
     <div className="flex items-center">
-      <Button className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey">
+      <Button
+        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
+        onClick={() => navigateDownTilZero()}
+      >
         <img src="/assets/left_icon.svg" alt="left icon" />
       </Button>
       <span className="flex justify-center items-center w-20 h-8 mr-1 rounded-md bg-white">
-        0 / 0
+        {currentDocIndexShownToUser} / {documentsNum}
       </span>
-      <Button className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey">
+      <Button
+        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
+        onClick={() => navigateDownTilMaxNum()}
+      >
         <img src="/assets/right_icon.svg" alt="right icon" />
       </Button>
       <Button
@@ -42,6 +95,9 @@ function DocHandlerButtons({ user, currentDBId }) {
 
 DocHandlerButtons.propTypes = {
   user: PropTypes.string.isRequired,
+  currentDBId: PropTypes.string.isRequired,
+  currentDocIndex: PropTypes.number.isRequired,
+  clickHandleNavigator: PropTypes.func.isRequired,
 };
 
 export default DocHandlerButtons;

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,9 +1,13 @@
 import Button from "../shared/Button";
 
-function SaveButton() {
+function SaveButton({ isEditMode, onClickSave }) {
   return (
     <div className="flex w-20 justify-center items-center">
-      <Button className="w-20 h-8 rounded-md ring-4 bg-white ring-blue hover:bg-blue">
+      <Button
+        className={`w-20 h-8 rounded-md ring-4 bg-white ring-blue hover:bg-blue
+        ${isEditMode ? "" : "hidden"}`}
+        onClick={() => onClickSave(false)}
+      >
         Save
       </Button>
     </div>

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -1,13 +1,37 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
 import Button from "../shared/Button";
 
 function SwitchViewButtons() {
+  const [isListView, setIsListView] = useState(true);
+  const navigate = useNavigate();
+
+  function switchToListView() {
+    setIsListView(true);
+    navigate("/dashboard/listview");
+  }
+
+  function switchToDetailView() {
+    setIsListView(false);
+    navigate("/dashboard/detailview");
+  }
+
   return (
     <div className="flex">
-      <Button className="flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow active:bg-yellow">
+      <Button
+        className={`flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow
+        ${isListView ? "bg-yellow" : "bg-white"}`}
+        onClick={switchToListView}
+      >
         <img className="ml-1" src="/assets/list_icon.svg" alt="list icon" />
         <span className="w-full">List View</span>
       </Button>
-      <Button className="flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow active:bg-yellow">
+      <Button
+        className={`flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow active:bg-yellow
+        ${!isListView ? "bg-yellow" : "bg-white"}`}
+        onClick={switchToDetailView}
+      >
         <img className="ml-1" src="/assets/detail_icon.svg" alt="detail icon" />
         <span className="w-full">Detail View</span>
       </Button>

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -4,11 +4,16 @@ import RelationButton from "./RelationButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
-function Toolbar({ user, currentDBId }) {
+function Toolbar({ user, currentDBId, currentDocIndex, clickHandleNavigator }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
       <RelationButton />
-      <DocHandlerButtons user={user} currentDBId={currentDBId} />
+      <DocHandlerButtons
+        user={user}
+        currentDBId={currentDBId}
+        currentDocIndex={currentDocIndex}
+        clickHandleNavigator={clickHandleNavigator}
+      />
       <SwitchViewButtons />
     </div>
   );
@@ -17,6 +22,8 @@ function Toolbar({ user, currentDBId }) {
 Toolbar.propTypes = {
   user: PropTypes.string.isRequired,
   currentDBId: PropTypes.string.isRequired,
+  currentDocIndex: PropTypes.number.isRequired,
+  clickHandleNavigator: PropTypes.func.isRequired,
 };
 
 export default Toolbar;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -7,7 +7,7 @@ import fetchData from "../utils/axios";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateDBModal";
 
-function Sidebar({ user, currentDBId, setCurrentDBId }) {
+function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 

--- a/src/components/contents/ContentsItems/DetailViewFields.jsx
+++ b/src/components/contents/ContentsItems/DetailViewFields.jsx
@@ -1,0 +1,50 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+function DetailViewFields({
+  docData,
+  isEditMode,
+  updateFieldValue,
+  setIsEditMode,
+  isDragging,
+  startDragging,
+  endDragging,
+}) {
+  return docData.map((element, index) => {
+    return (
+      <div
+        key={element.field_id}
+        className={`absolute w-[350px]
+          ${isEditMode && isDragging ? "rounded-md drop-shadow-md" : null}
+        `}
+        style={{
+          top: `${element.coordinates.y}px`,
+          left: `${element.coordinates.x}px`,
+        }}
+      >
+        <div className="flex w-full p-2">
+          <span
+            className={`flex justify-end mr-3 w-[100px] select-none
+            ${isEditMode ? "hover:cursor-move" : null}`}
+            onMouseDown={event => startDragging(index, event)}
+            onMouseUp={() => endDragging(index)}
+          >
+            {element.name}
+          </span>
+          <textarea
+            className={`flex w-full h-7 mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
+              isEditMode && !isDragging
+                ? "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+                : null
+            }`}
+            maxLength="15"
+            onDoubleClick={() => setIsEditMode(true)}
+            onChange={event => updateFieldValue(index, event)}
+            value={element.value}
+            readOnly={!isEditMode}
+          />
+        </div>
+      </div>
+    );
+  });
+}
+
+export default DetailViewFields;

--- a/src/components/contents/DetailView.jsx
+++ b/src/components/contents/DetailView.jsx
@@ -1,7 +1,12 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import { useState, useEffect } from "react";
 // import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
+
+import DetailViewFields from "./ContentsItems/DetailViewFields";
+
+import CONSTANT from "../../constants/constant";
+
+const { XdragAdjustment, YdragAdjustment } = CONSTANT;
 
 // import fetchData from "../../utils/axios";
 
@@ -72,19 +77,21 @@ function DetailView({
     if (isEditMode && isDragging) {
       const newArr = [...docData];
 
-      newArr[draggedElementIndex].coordinates.x = event.clientX - 330;
-      newArr[draggedElementIndex].coordinates.y = event.clientY - 177;
+      newArr[draggedElementIndex].coordinates.x =
+        event.clientX - XdragAdjustment;
+      newArr[draggedElementIndex].coordinates.y =
+        event.clientY - YdragAdjustment;
 
       setDocData(newArr);
     }
   };
 
-  function startToggle(index) {
+  function startDragging(index) {
     setIsDragging(true);
     setDraggedElementIndex(index);
   }
 
-  function endToggle() {
+  function endDragging() {
     setIsDragging(false);
     setDraggedElementIndex(null);
   }
@@ -93,7 +100,7 @@ function DetailView({
     const arr = [];
 
     mockUp[currentDocIndex].elements.forEach((element, index) => {
-      return arr.push({
+      arr.push({
         field_id: element._id,
         name: element.name,
         coordinates: { x: 0, y: index * 40 },
@@ -112,46 +119,6 @@ function DetailView({
     setDocData(newArr);
   }
 
-  function renderFields(parameter) {
-    return parameter.map((element, index) => {
-      return (
-        <div
-          key={element.field_id}
-          className={`absolute w-[350px]
-            ${isEditMode && isDragging ? "rounded-md drop-shadow-md" : null}
-          `}
-          style={{
-            top: `${element.coordinates.y}px`,
-            left: `${element.coordinates.x}px`,
-          }}
-        >
-          <div className="flex w-full p-2">
-            <span
-              className={`flex justify-end mr-3 w-[100px] select-none
-              ${isEditMode ? "hover:cursor-move" : null}`}
-              onMouseDown={event => startToggle(index, event)}
-              onMouseUp={() => endToggle(index)}
-            >
-              {element.name}
-            </span>
-            <textarea
-              className={`flex w-full h-7 mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
-                isEditMode && !isDragging
-                  ? "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
-                  : null
-              }`}
-              maxLength="15"
-              onDoubleClick={() => setIsEditMode(true)}
-              onChange={event => updateFieldValue(index, event)}
-              value={element.value}
-              readOnly={!isEditMode}
-            />
-          </div>
-        </div>
-      );
-    });
-  }
-
   return (
     <div className="flex w-full bg-grey">
       <div
@@ -162,7 +129,15 @@ function DetailView({
         onMouseMove={event => handleMouseMove(event)}
       >
         <div className="flex flex-col absolute w-[150px] h-10 ">
-          {renderFields(docData)}
+          <DetailViewFields
+            docData={docData}
+            isEditMode={isEditMode}
+            updateFieldValue={updateFieldValue}
+            setIsEditMode={setIsEditMode}
+            isDragging={isDragging}
+            startDragging={startDragging}
+            endDragging={endDragging}
+          />
         </div>
       </div>
     </div>

--- a/src/components/contents/DetailView.jsx
+++ b/src/components/contents/DetailView.jsx
@@ -1,0 +1,179 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import { useState, useEffect } from "react";
+// import { useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
+
+// import fetchData from "../../utils/axios";
+
+function DetailView({
+  isEditMode,
+  setIsEditMode,
+  currentDocIndex,
+  // user,
+  // currentDBId,
+  // documentsIds,
+}) {
+  const [docData, setDocData] = useState([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [draggedElementIndex, setDraggedElementIndex] = useState(null);
+
+  const mockUp = [
+    {
+      _id: "64c0df15d1635c84c3170f41",
+      elements: [
+        {
+          name: "내용",
+          value: "첫번째 실험",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f42",
+        },
+        {
+          name: "만든날짜",
+          value: "2023.07.26",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f43",
+        },
+        {
+          name: "만든시각",
+          value: "17:53",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f44",
+        },
+      ],
+      __v: 0,
+    },
+    {
+      _id: "64c0df15d1635c84c3170f41",
+      elements: [
+        {
+          name: "내용",
+          value: "두번째 실험",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f42",
+        },
+        {
+          name: "만든날짜",
+          value: "2023.07.27",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f43",
+        },
+        {
+          name: "만든시각",
+          value: "1:40",
+          coordinates: { x: 0, y: 0 },
+          _id: "64c0df15d1635c84c3170f44",
+        },
+      ],
+      __v: 0,
+    },
+  ];
+
+  const handleMouseMove = event => {
+    if (isEditMode && isDragging) {
+      const newArr = [...docData];
+
+      newArr[draggedElementIndex].coordinates.x = event.clientX - 330;
+      newArr[draggedElementIndex].coordinates.y = event.clientY - 177;
+
+      setDocData(newArr);
+    }
+  };
+
+  function startToggle(index) {
+    setIsDragging(true);
+    setDraggedElementIndex(index);
+  }
+
+  function endToggle() {
+    setIsDragging(false);
+    setDraggedElementIndex(null);
+  }
+
+  useEffect(() => {
+    const arr = [];
+
+    mockUp[currentDocIndex].elements.forEach((element, index) => {
+      return arr.push({
+        field_id: element._id,
+        name: element.name,
+        coordinates: { x: 0, y: index * 40 },
+        value: element.value,
+      });
+    });
+
+    setDocData(arr);
+  }, [currentDocIndex]);
+
+  function updateFieldValue(index, event) {
+    const newArr = [...docData];
+
+    newArr[index].value = event.target.value;
+
+    setDocData(newArr);
+  }
+
+  function renderFields(parameter) {
+    return parameter.map((element, index) => {
+      return (
+        <div
+          key={element.field_id}
+          className={`absolute w-[350px]
+            ${isEditMode && isDragging ? "rounded-md drop-shadow-md" : null}
+          `}
+          style={{
+            top: `${element.coordinates.y}px`,
+            left: `${element.coordinates.x}px`,
+          }}
+        >
+          <div className="flex w-full p-2">
+            <span
+              className={`flex justify-end mr-3 w-[100px] select-none
+              ${isEditMode ? "hover:cursor-move" : null}`}
+              onMouseDown={event => startToggle(index, event)}
+              onMouseUp={() => endToggle(index)}
+            >
+              {element.name}
+            </span>
+            <textarea
+              className={`flex w-full h-7 mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
+                isEditMode && !isDragging
+                  ? "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+                  : null
+              }`}
+              maxLength="15"
+              onDoubleClick={() => setIsEditMode(true)}
+              onChange={event => updateFieldValue(index, event)}
+              value={element.value}
+              readOnly={!isEditMode}
+            />
+          </div>
+        </div>
+      );
+    });
+  }
+
+  return (
+    <div className="flex w-full bg-grey">
+      <div
+        className={`flex w-full m-2 p-5 bg-white drop-shadow-md ${
+          isEditMode ? "ring-4 ring-blue" : null
+        }
+      `}
+        onMouseMove={event => handleMouseMove(event)}
+      >
+        <div className="flex flex-col absolute w-[150px] h-10 ">
+          {renderFields(docData)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DetailView.propTypes = {
+  // user: PropTypes.string.isRequired,
+  // currentDBId: PropTypes.string.isRequired,
+  isEditMode: PropTypes.bool.isRequired,
+  setIsEditMode: PropTypes.func.isRequired,
+};
+
+export default DetailView;

--- a/src/components/contents/ListView.jsx
+++ b/src/components/contents/ListView.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
-function ListView({ user, currentDBId }) {
+function ListView({ user, currentDBId, setDocumentsIds }) {
   async function getDocumentsList() {
     const response = await fetchData(
       "GET",
@@ -15,9 +15,19 @@ function ListView({ user, currentDBId }) {
 
   const { data, isLoading } = useQuery(["dbDocumentList"], getDocumentsList, {
     enabled: !!user,
+    onSuccess: result => {
+      const newArr = [];
+
+      result.data.database.documents.forEach(element => {
+        return newArr.push(element._id);
+      });
+
+      setDocumentsIds(newArr);
+    },
     onFailure: () => {
       console.log("sending user to errorpage");
     },
+    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {

--- a/src/components/contents/ListView.jsx
+++ b/src/components/contents/ListView.jsx
@@ -19,7 +19,7 @@ function ListView({ user, currentDBId, setDocumentsIds }) {
       const newArr = [];
 
       result.data.database.documents.forEach(element => {
-        return newArr.push(element._id);
+        newArr.push(element._id);
       });
 
       setDocumentsIds(newArr);

--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -11,6 +11,8 @@ const CONSTANT = {
   maxDatabaseNameLength: 15,
   maxfieldNameLength: 20,
   oneHourInMillisecond: 1000 * 60 * 60,
+  XdragAdjustment: 330,
+  YdragAdjustment: 177,
 };
 
 export default CONSTANT;


### PR DESCRIPTION
### [노션 칸반 - [FE] detail view](https://www.notion.so/FE-Document-Detail-View-8df7cbb95b844881b5fcf3bedee8da9c?pvs=4)

### description

mockup data를 이용하고 있는 관계로 미래 사용될 prop에 대한 주석처리가 있습니다.
이 부분 참고 부탁드립니다.

#### Header:
1. < & > navigation buttons를 통해서 App의 state내부 index를 변경할 수 있습니다.

- 최소: 1,
최대: document개수 length
룰 적용 완료했습니다.
  
- 유저에게는 최소단위가 1로 보이지만, 실제 내부 데이터는 index의 특성에 따라 0입니다. 참고 부탁드립니다.
  
- 네비게이터 조작에 따라서 detail view가 동적으로 내용을 리렌더하도록 로직 적용하였습니다.
  
- 현재는 Mockup 배열 내 정보를 참고하며 index 이동을 하지만, 실제 document를 GET할 때를 고려해서 App 컴포넌트 내부의 documentIds 배열이 준비되어있습니다.
  유저가 보고자 하는 순번이 바뀔 때마다 그에 해당하는 배열내부 id 를 이용하여 GET을 하고 리렌더링해 줄 예정입니다.

3. list view와 detail view 버튼으로 view를 전환할 수 있습니다.

4. save버튼이 edit 모드에 진입하는 경우 나타나며. edit 모드를 종료하는 경우 hidden이 됩니다.
save모드가 종료되면 detailView의 state내부에 있는 최신상태의 데이터가 server로 전송될 예정입니다.

#### DetailView:
1. drag and drop으로 라벨 부분을 잡고 움직이면 위치를 바꾸고, 바뀐 위치를 state 내부의 각 field별 coordinates에 저장하도록 하였습니다. 라벨 부분은 글자 select를 제한하였고, 잡고 움직일 수 있다는 사실을 유저가 직관적으로 알 수 있도록 해서 UX를 최적화했습니다.

2. fields의 모든 정보를 아우르는 객체는 save모드가 종료되면 서버로 fetch됩니다.
coordinates역시 edit 모드일 때만 조작이 가능하도록 하여 기존 value변경완료시 fetch 타이밍에 끼워넣도록 했습니다.

### concern

- 실제 GET과 PUT이 가능하게 되면 다시 리팩토링이 진행될 예정입니다.
- 더블클릭을 통해 edit mode에 들어갈 수 있음을 시사하는 부분을 고민해야하지 않을까 생각합니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Jul-27-2023 13-41-09](https://github.com/Team-Dataface/DataFace-client/assets/83858724/9fc1df82-ea0a-4445-b9c9-3157b9dc0aa2)

