### PR TITLE
Refactor. implement useContext and remove prop drilling

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import UserContext from "../context/UserContext";
+import CurrentDBIdContext from "../context/CurrentDBIdContext";
 import authUser from "../utils/authUser";
 import Login from "../components/Login";
 import Header from "../components/Header";
@@ -48,65 +49,63 @@ function App() {
 
   return (
     <UserContext.Provider value={user}>
-      <div className="flex flex-col h-screen">
-        {user && (
-          <Header
-            clickHandleLogout={setUser}
-            currentDBId={currentDBId}
-            isEditMode={isEditMode}
-            onClickSave={setIsEditMode}
-            currentDocIndex={currentDocIndex}
-            clickHandleNavigator={setCurrentDocIndex}
-          />
-        )}
-        <div className="flex flex-1">
+      <CurrentDBIdContext.Provider value={currentDBId}>
+        <div className="flex flex-col h-screen">
           {user && (
-            <Sidebar
-              currentDBId={currentDBId}
-              setCurrentDBId={setCurrentDBId}
-              setDocumentsIds={setDocumentsIds}
+            <Header
+              clickHandleLogout={setUser}
+              isEditMode={isEditMode}
+              onClickSave={setIsEditMode}
+              currentDocIndex={currentDocIndex}
+              clickHandleNavigator={setCurrentDocIndex}
             />
           )}
-          <div className="flex grow justify-center">
-            <Routes>
-              <Route path="/login" element={<Login setUser={setUser} />} />
-              <Route path="/dashboard" element={<ContentsContainer />}>
-                <Route
-                  path="listview"
-                  element={
-                    <ListView
-                      currentDBId={currentDBId}
-                      isEditMode={isEditMode}
-                      setIsSaveMode={setIsEditMode}
-                      currentDocIndex={currentDocIndex}
-                      setCurrentDocIndex={setCurrentDocIndex}
-                      setDocumentsIds={setDocumentsIds}
-                    />
-                  }
-                />
-                <Route
-                  path="detailview"
-                  element={
-                    <DetailView
-                      currentDBId={currentDBId}
-                      isEditMode={isEditMode}
-                      setIsEditMode={setIsEditMode}
-                      currentDocIndex={currentDocIndex}
-                      setCurrentDocIndex={setCurrentDocIndex}
-                      documentsIds={documentsIds}
-                    />
-                  }
-                />
-                <Route
-                  path="nodatabase"
-                  element={<NoDatabase setCurrentDBId={setCurrentDBId} />}
-                />
-              </Route>
-              <Route path="/" element={<Navigate replace to="/login" />} />
-            </Routes>
+          <div className="flex flex-1">
+            {user && (
+              <Sidebar
+                setCurrentDBId={setCurrentDBId}
+                setDocumentsIds={setDocumentsIds}
+              />
+            )}
+            <div className="flex grow justify-center">
+              <Routes>
+                <Route path="/login" element={<Login setUser={setUser} />} />
+                <Route path="/dashboard" element={<ContentsContainer />}>
+                  <Route
+                    path="listview"
+                    element={
+                      <ListView
+                        isEditMode={isEditMode}
+                        setIsSaveMode={setIsEditMode}
+                        currentDocIndex={currentDocIndex}
+                        setCurrentDocIndex={setCurrentDocIndex}
+                        setDocumentsIds={setDocumentsIds}
+                      />
+                    }
+                  />
+                  <Route
+                    path="detailview"
+                    element={
+                      <DetailView
+                        isEditMode={isEditMode}
+                        setIsEditMode={setIsEditMode}
+                        currentDocIndex={currentDocIndex}
+                        setCurrentDocIndex={setCurrentDocIndex}
+                        documentsIds={documentsIds}
+                      />
+                    }
+                  />
+                  <Route
+                    path="nodatabase"
+                    element={<NoDatabase setCurrentDBId={setCurrentDBId} />}
+                  />
+                </Route>
+                <Route path="/" element={<Navigate replace to="/login" />} />
+              </Routes>
+            </div>
           </div>
         </div>
-      </div>
+      </CurrentDBIdContext.Provider>
     </UserContext.Provider>
   );
 }

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
+import UserContext from "../context/UserContext";
 import authUser from "../utils/authUser";
 import Login from "../components/Login";
 import Header from "../components/Header";
@@ -46,74 +47,67 @@ function App() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
-      {user && (
-        <Header
-          user={user}
-          clickHandleLogout={setUser}
-          currentDBId={currentDBId}
-          isEditMode={isEditMode}
-          onClickSave={setIsEditMode}
-          currentDocIndex={currentDocIndex}
-          clickHandleNavigator={setCurrentDocIndex}
-        />
-      )}
-      <div className="flex flex-1">
+    <UserContext.Provider value={user}>
+      <div className="flex flex-col h-screen">
         {user && (
-          <Sidebar
-            user={user}
+          <Header
+            clickHandleLogout={setUser}
             currentDBId={currentDBId}
-            setCurrentDBId={setCurrentDBId}
-            setDocumentsIds={setDocumentsIds}
+            isEditMode={isEditMode}
+            onClickSave={setIsEditMode}
+            currentDocIndex={currentDocIndex}
+            clickHandleNavigator={setCurrentDocIndex}
           />
         )}
-        <div className="flex grow justify-center">
-          <Routes>
-            <Route path="/login" element={<Login setUser={setUser} />} />
-            <Route
-              path="/dashboard"
-              element={<ContentsContainer user={user} />}
-            >
-              <Route
-                path="listview"
-                element={
-                  <ListView
-                    user={user}
-                    currentDBId={currentDBId}
-                    isEditMode={isEditMode}
-                    setIsSaveMode={setIsEditMode}
-                    currentDocIndex={currentDocIndex}
-                    setCurrentDocIndex={setCurrentDocIndex}
-                    setDocumentsIds={setDocumentsIds}
-                  />
-                }
-              />
-              <Route
-                path="detailview"
-                element={
-                  <DetailView
-                    user={user}
-                    currentDBId={currentDBId}
-                    isEditMode={isEditMode}
-                    setIsEditMode={setIsEditMode}
-                    currentDocIndex={currentDocIndex}
-                    setCurrentDocIndex={setCurrentDocIndex}
-                    documentsIds={documentsIds}
-                  />
-                }
-              />
-              <Route
-                path="nodatabase"
-                element={
-                  <NoDatabase user={user} setCurrentDBId={setCurrentDBId} />
-                }
-              />
-            </Route>
-            <Route path="/" element={<Navigate replace to="/login" />} />
-          </Routes>
+        <div className="flex flex-1">
+          {user && (
+            <Sidebar
+              currentDBId={currentDBId}
+              setCurrentDBId={setCurrentDBId}
+              setDocumentsIds={setDocumentsIds}
+            />
+          )}
+          <div className="flex grow justify-center">
+            <Routes>
+              <Route path="/login" element={<Login setUser={setUser} />} />
+              <Route path="/dashboard" element={<ContentsContainer />}>
+                <Route
+                  path="listview"
+                  element={
+                    <ListView
+                      currentDBId={currentDBId}
+                      isEditMode={isEditMode}
+                      setIsSaveMode={setIsEditMode}
+                      currentDocIndex={currentDocIndex}
+                      setCurrentDocIndex={setCurrentDocIndex}
+                      setDocumentsIds={setDocumentsIds}
+                    />
+                  }
+                />
+                <Route
+                  path="detailview"
+                  element={
+                    <DetailView
+                      currentDBId={currentDBId}
+                      isEditMode={isEditMode}
+                      setIsEditMode={setIsEditMode}
+                      currentDocIndex={currentDocIndex}
+                      setCurrentDocIndex={setCurrentDocIndex}
+                      documentsIds={documentsIds}
+                    />
+                  }
+                />
+                <Route
+                  path="nodatabase"
+                  element={<NoDatabase setCurrentDBId={setCurrentDBId} />}
+                />
+              </Route>
+              <Route path="/" element={<Navigate replace to="/login" />} />
+            </Routes>
+          </div>
         </div>
       </div>
-    </div>
+    </UserContext.Provider>
   );
 }
 

--- a/src/components/ContentsContainer.jsx
+++ b/src/components/ContentsContainer.jsx
@@ -1,20 +1,23 @@
+import { useContext } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import PropTypes from "prop-types";
 
 import fetchData from "../utils/axios";
 
-function ContentsContainer({ user }) {
+import UserContext from "../context/UserContext";
+
+function ContentsContainer() {
   const navigate = useNavigate();
+  const { userId } = useContext(UserContext);
 
   async function getDatabaseList() {
-    const response = await fetchData("GET", `users/${user.userId}/databases`);
+    const response = await fetchData("GET", `users/${userId}/databases`);
 
     return response;
   }
 
   const { isLoading } = useQuery(["userDbList"], getDatabaseList, {
-    enabled: !!user,
+    enabled: !!userId,
     onSuccess: result => {
       if (!result.length) {
         navigate("/dashboard/nodatabase");
@@ -35,9 +38,5 @@ function ContentsContainer({ user }) {
 
   return <Outlet />;
 }
-
-ContentsContainer.propTypes = {
-  user: PropTypes.string.isRequired,
-};
 
 export default ContentsContainer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,7 +6,6 @@ import SaveButton from "./HeaderItems/SaveButton";
 
 function Header({
   clickHandleLogout,
-  currentDBId,
   isEditMode,
   onClickSave,
   currentDocIndex,
@@ -26,7 +25,6 @@ function Header({
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
         <Toolbar
-          currentDBId={currentDBId}
           currentDocIndex={currentDocIndex}
           clickHandleNavigator={clickHandleNavigator}
         />
@@ -38,7 +36,6 @@ function Header({
 
 Header.propTypes = {
   clickHandleLogout: PropTypes.func.isRequired,
-  currentDBId: PropTypes.string.isRequired,
   isEditMode: PropTypes.bool.isRequired,
   onClickSave: PropTypes.func.isRequired,
   currentDocIndex: PropTypes.number.isRequired,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import PropTypes from "prop-types";
 
 import LogoutButton from "./HeaderItems/LogoutButton";
@@ -6,7 +5,6 @@ import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
 function Header({
-  user,
   clickHandleLogout,
   currentDBId,
   isEditMode,
@@ -28,7 +26,6 @@ function Header({
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
         <Toolbar
-          user={user}
           currentDBId={currentDBId}
           currentDocIndex={currentDocIndex}
           clickHandleNavigator={clickHandleNavigator}
@@ -40,7 +37,6 @@ function Header({
 }
 
 Header.propTypes = {
-  user: PropTypes.string.isRequired,
   clickHandleLogout: PropTypes.func.isRequired,
   currentDBId: PropTypes.string.isRequired,
   isEditMode: PropTypes.bool.isRequired,

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -5,17 +5,16 @@ import PropTypes from "prop-types";
 import fetchData from "../../utils/axios";
 
 import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 import Button from "../shared/Button";
 import AddDocumentModal from "../Modals/AddDocumentModal";
 
-function DocHandlerButtons({
-  currentDBId,
-  currentDocIndex,
-  clickHandleNavigator,
-}) {
+function DocHandlerButtons({ currentDocIndex, clickHandleNavigator }) {
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
   const [documentsNum, setDocumentsNum] = useState(0);
+
   const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   const currentDocIndexShownToUser = currentDocIndex + 1;
 
@@ -99,7 +98,6 @@ function DocHandlerButtons({
 }
 
 DocHandlerButtons.propTypes = {
-  currentDBId: PropTypes.string.isRequired,
   currentDocIndex: PropTypes.number.isRequired,
   clickHandleNavigator: PropTypes.func.isRequired,
 };

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,20 +1,21 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
+import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
 import AddDocumentModal from "../Modals/AddDocumentModal";
 
 function DocHandlerButtons({
-  user,
   currentDBId,
   currentDocIndex,
   clickHandleNavigator,
 }) {
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
   const [documentsNum, setDocumentsNum] = useState(0);
+  const { userId } = useContext(UserContext);
 
   const currentDocIndexShownToUser = currentDocIndex + 1;
 
@@ -33,7 +34,7 @@ function DocHandlerButtons({
   async function getDocumentsList() {
     const response = await fetchData(
       "GET",
-      `users/${user.userId}/databases/${currentDBId}`,
+      `users/${userId}/databases/${currentDBId}`,
     );
 
     return response.data.database.documents;
@@ -44,7 +45,7 @@ function DocHandlerButtons({
     getDocumentsList,
     {
       retry: false,
-      enabled: !!user && !!currentDBId,
+      enabled: !!userId && !!currentDBId,
       onSuccess: result => {
         setDocumentsNum(result.length);
       },
@@ -89,7 +90,6 @@ function DocHandlerButtons({
       </Button>
       {showAddDocumentModal && (
         <AddDocumentModal
-          user={user}
           closeModal={() => setShowAddDocumentModal(false)}
           currentDBId={currentDBId}
         />
@@ -99,7 +99,6 @@ function DocHandlerButtons({
 }
 
 DocHandlerButtons.propTypes = {
-  user: PropTypes.string.isRequired,
   currentDBId: PropTypes.string.isRequired,
   currentDocIndex: PropTypes.number.isRequired,
   clickHandleNavigator: PropTypes.func.isRequired,

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -4,12 +4,11 @@ import RelationButton from "./RelationButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
-function Toolbar({ user, currentDBId, currentDocIndex, clickHandleNavigator }) {
+function Toolbar({ currentDBId, currentDocIndex, clickHandleNavigator }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
       <RelationButton />
       <DocHandlerButtons
-        user={user}
         currentDBId={currentDBId}
         currentDocIndex={currentDocIndex}
         clickHandleNavigator={clickHandleNavigator}
@@ -20,7 +19,6 @@ function Toolbar({ user, currentDBId, currentDocIndex, clickHandleNavigator }) {
 }
 
 Toolbar.propTypes = {
-  user: PropTypes.string.isRequired,
   currentDBId: PropTypes.string.isRequired,
   currentDocIndex: PropTypes.number.isRequired,
   clickHandleNavigator: PropTypes.func.isRequired,

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -4,12 +4,11 @@ import RelationButton from "./RelationButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
-function Toolbar({ currentDBId, currentDocIndex, clickHandleNavigator }) {
+function Toolbar({ currentDocIndex, clickHandleNavigator }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
       <RelationButton />
       <DocHandlerButtons
-        currentDBId={currentDBId}
         currentDocIndex={currentDocIndex}
         clickHandleNavigator={clickHandleNavigator}
       />
@@ -19,7 +18,6 @@ function Toolbar({ currentDBId, currentDocIndex, clickHandleNavigator }) {
 }
 
 Toolbar.propTypes = {
-  currentDBId: PropTypes.string.isRequired,
   currentDocIndex: PropTypes.number.isRequired,
   clickHandleNavigator: PropTypes.func.isRequired,
 };

--- a/src/components/Modals/AddDocumentListSection.jsx
+++ b/src/components/Modals/AddDocumentListSection.jsx
@@ -1,15 +1,17 @@
 import { useContext } from "react";
-import PropTypes from "prop-types";
 import { useQuery } from "@tanstack/react-query";
+import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
 import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 import ModalLabel from "./ModalLabel";
 import ModalInputArea from "./ModalInputArea";
 
-function AddDocumentListSection({ updateFieldValue, currentDBId, setFields }) {
+function AddDocumentListSection({ updateFieldValue, setFields }) {
   const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   async function getDatabase() {
     const response = await fetchData(

--- a/src/components/Modals/AddDocumentListSection.jsx
+++ b/src/components/Modals/AddDocumentListSection.jsx
@@ -1,28 +1,27 @@
+import { useContext } from "react";
 import PropTypes from "prop-types";
 import { useQuery } from "@tanstack/react-query";
 
 import fetchData from "../../utils/axios";
 
+import UserContext from "../../context/UserContext";
 import ModalLabel from "./ModalLabel";
 import ModalInputArea from "./ModalInputArea";
 
-function AddDocumentListSection({
-  user,
-  updateFieldValue,
-  currentDBId,
-  setFields,
-}) {
+function AddDocumentListSection({ updateFieldValue, currentDBId, setFields }) {
+  const { userId } = useContext(UserContext);
+
   async function getDatabase() {
     const response = await fetchData(
       "GET",
-      `users/${user.userId}/databases/${currentDBId}`,
+      `users/${userId}/databases/${currentDBId}`,
     );
 
     return response.data.database.documents[0];
   }
 
   const { data, isLoading } = useQuery(["userDb"], getDatabase, {
-    enabled: !!user,
+    enabled: !!userId,
     onSuccess: result => {
       setFields(result.fields);
     },

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -6,15 +6,17 @@ import PropTypes from "prop-types";
 import fetchData from "../../utils/axios";
 
 import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 import Button from "../shared/Button";
 import Modal from "../shared/Modal";
 import ModalTitle from "./ModalTitle";
 import AddDocumentListSection from "./AddDocumentListSection";
 
-function AddDocumentModal({ closeModal, currentDBId }) {
+function AddDocumentModal({ closeModal }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   const [fields, setFields] = useState([]);
 
@@ -73,7 +75,6 @@ function AddDocumentModal({ closeModal, currentDBId }) {
 
 AddDocumentModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
-  currentDBId: PropTypes.string.isRequired,
 };
 
 export default AddDocumentModal;

--- a/src/components/Modals/AddDocumentModal.jsx
+++ b/src/components/Modals/AddDocumentModal.jsx
@@ -1,18 +1,21 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
+import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
 import Modal from "../shared/Modal";
 import ModalTitle from "./ModalTitle";
 import AddDocumentListSection from "./AddDocumentListSection";
 
-function AddDocumentModal({ user, closeModal, currentDBId }) {
+function AddDocumentModal({ closeModal, currentDBId }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { userId } = useContext(UserContext);
+
   const [fields, setFields] = useState([]);
 
   function updateFieldValue(index, event) {
@@ -24,7 +27,7 @@ function AddDocumentModal({ user, closeModal, currentDBId }) {
   async function handleClickSave() {
     await fetchData(
       "POST",
-      `/users/${user.userId}/databases/${currentDBId}/documents`,
+      `/users/${userId}/databases/${currentDBId}/documents`,
       fields,
     );
   }
@@ -48,7 +51,6 @@ function AddDocumentModal({ user, closeModal, currentDBId }) {
           <div className="flex">
             <div className="flex flex-col items-center p-3">
               <AddDocumentListSection
-                user={user}
                 updateFieldValue={updateFieldValue}
                 currentDBId={currentDBId}
                 setFields={setFields}
@@ -70,7 +72,6 @@ function AddDocumentModal({ user, closeModal, currentDBId }) {
 }
 
 AddDocumentModal.propTypes = {
-  user: PropTypes.string.isRequired,
   closeModal: PropTypes.func.isRequired,
   currentDBId: PropTypes.string.isRequired,
 };

--- a/src/components/Modals/CreateDBModal.jsx
+++ b/src/components/Modals/CreateDBModal.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../utils/axios";
 
+import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
 import Modal from "../shared/Modal";
 import CreateDBListSection from "./CreateDBListSection";
@@ -14,9 +15,11 @@ import ModalInputArea from "./ModalInputArea";
 
 import CONSTANT from "../../constants/constant";
 
-function CreateDBModal({ user, closeModal, setCurrentDBId }) {
+function CreateDBModal({ closeModal, setCurrentDBId }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { userId } = useContext(UserContext);
+
   const [dbName, setdbName] = useState(null);
   const [fields, setFields] = useState([
     {
@@ -80,7 +83,7 @@ function CreateDBModal({ user, closeModal, setCurrentDBId }) {
 
     const response = await fetchData(
       "POST",
-      `/users/${user.userId}/databases`,
+      `/users/${userId}/databases`,
       newDatabase,
     );
 
@@ -155,7 +158,6 @@ function CreateDBModal({ user, closeModal, setCurrentDBId }) {
 }
 
 CreateDBModal.propTypes = {
-  user: PropTypes.string.isRequired,
   closeModal: PropTypes.func.isRequired,
 };
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,13 +5,16 @@ import PropTypes from "prop-types";
 import fetchData from "../utils/axios";
 
 import UserContext from "../context/UserContext";
+import CurrentDBIdContext from "../context/CurrentDBIdContext";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateDBModal";
 
-function Sidebar({ currentDBId, setCurrentDBId }) {
+function Sidebar({ setCurrentDBId }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
+
   const { userId, username } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   async function deleteDatabase(databaseId) {
     await fetchData("DELETE", `/users/${userId}/databases/${databaseId}`);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,18 +1,20 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import PropTypes from "prop-types";
 import fetchData from "../utils/axios";
 
+import UserContext from "../context/UserContext";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateDBModal";
 
-function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
+function Sidebar({ currentDBId, setCurrentDBId }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
+  const { userId, username } = useContext(UserContext);
 
   async function deleteDatabase(databaseId) {
-    await fetchData("DELETE", `/users/${user.userId}/databases/${databaseId}`);
+    await fetchData("DELETE", `/users/${userId}/databases/${databaseId}`);
   }
 
   const { mutate: fetchDeleteDB } = useMutation(deleteDatabase, {
@@ -25,7 +27,7 @@ function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
   });
 
   async function getDatabaseList() {
-    const response = await fetchData("GET", `users/${user.userId}/databases`);
+    const response = await fetchData("GET", `users/${userId}/databases`);
 
     return response.data.databases;
   }
@@ -34,7 +36,7 @@ function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
     ["userDbList"],
     getDatabaseList,
     {
-      enabled: !!user,
+      enabled: !!userId,
       onSuccess: result => {
         if (result.length) {
           setCurrentDBId(result[0]._id);
@@ -102,7 +104,7 @@ function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
       <div className="flex flex-col w-full">
         <div className="flex h-10 ml-2 items-center">
           <img className="mr-2" src="/assets/DB_icon.svg" alt="DB icon" />
-          <p className="font-bold">{user.username}</p>
+          <p className="font-bold">{username}</p>
         </div>
         {databases && <ul className="mb-3">{renderDatabaseList()}</ul>}
       </div>
@@ -121,7 +123,6 @@ function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
       </div>
       {showCreateDBModal && (
         <CreateDBModal
-          user={user}
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
         />
@@ -131,7 +132,6 @@ function Sidebar({ user, currentDBId, setCurrentDBId, setDocumentsIds }) {
 }
 
 Sidebar.propTypes = {
-  user: PropTypes.string.isRequired,
   setCurrentDBId: PropTypes.func.isRequired,
 };
 

--- a/src/components/contents/DetailView.jsx
+++ b/src/components/contents/DetailView.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import PropTypes from "prop-types";
 
 import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 import DetailViewFields from "./ContentsItems/DetailViewFields";
 
 import CONSTANT from "../../constants/constant";
@@ -15,14 +16,14 @@ function DetailView({
   isEditMode,
   setIsEditMode,
   currentDocIndex,
-  // currentDBId,
   // documentsIds,
 }) {
-  const { userId } = useContext(UserContext);
-
   const [docData, setDocData] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
   const [draggedElementIndex, setDraggedElementIndex] = useState(null);
+
+  const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   const mockUp = [
     {
@@ -147,7 +148,6 @@ function DetailView({
 }
 
 DetailView.propTypes = {
-  // currentDBId: PropTypes.string.isRequired,
   isEditMode: PropTypes.bool.isRequired,
   setIsEditMode: PropTypes.func.isRequired,
 };

--- a/src/components/contents/DetailView.jsx
+++ b/src/components/contents/DetailView.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 // import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
+import UserContext from "../../context/UserContext";
 import DetailViewFields from "./ContentsItems/DetailViewFields";
 
 import CONSTANT from "../../constants/constant";
@@ -14,10 +15,11 @@ function DetailView({
   isEditMode,
   setIsEditMode,
   currentDocIndex,
-  // user,
   // currentDBId,
   // documentsIds,
 }) {
+  const { userId } = useContext(UserContext);
+
   const [docData, setDocData] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
   const [draggedElementIndex, setDraggedElementIndex] = useState(null);
@@ -145,7 +147,6 @@ function DetailView({
 }
 
 DetailView.propTypes = {
-  // user: PropTypes.string.isRequired,
   // currentDBId: PropTypes.string.isRequired,
   isEditMode: PropTypes.bool.isRequired,
   setIsEditMode: PropTypes.func.isRequired,

--- a/src/components/contents/ListView.jsx
+++ b/src/components/contents/ListView.jsx
@@ -1,13 +1,18 @@
+import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
+import UserContext from "../../context/UserContext";
+
 import fetchData from "../../utils/axios";
 
-function ListView({ user, currentDBId, setDocumentsIds }) {
+function ListView({ currentDBId, setDocumentsIds }) {
+  const { userId } = useContext(UserContext);
+
   async function getDocumentsList() {
     const response = await fetchData(
       "GET",
-      `users/${user.userId}/databases/${currentDBId}`,
+      `users/${userId}/databases/${currentDBId}`,
     );
 
     return response.data.database.documents;
@@ -17,11 +22,9 @@ function ListView({ user, currentDBId, setDocumentsIds }) {
     ["dbDocumentList", currentDBId],
     getDocumentsList,
     {
-      enabled: !!user,
+      enabled: !!userId,
       onSuccess: result => {
-        const newArr = [];
-
-        result.forEach(element => {
+        const newArr = result.forEach(element => {
           newArr.push(element._id);
         });
 
@@ -71,8 +74,8 @@ function ListView({ user, currentDBId, setDocumentsIds }) {
 }
 
 ListView.propTypes = {
-  user: PropTypes.string.isRequired,
   currentDBId: PropTypes.string.isRequired,
+  setDocumentsIds: PropTypes.func.isRequired,
 };
 
 export default ListView;

--- a/src/components/contents/ListView.jsx
+++ b/src/components/contents/ListView.jsx
@@ -3,11 +3,13 @@ import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 
 import fetchData from "../../utils/axios";
 
-function ListView({ currentDBId, setDocumentsIds }) {
+function ListView({ setDocumentsIds }) {
   const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
 
   async function getDocumentsList() {
     const response = await fetchData(
@@ -24,11 +26,9 @@ function ListView({ currentDBId, setDocumentsIds }) {
     {
       enabled: !!userId,
       onSuccess: result => {
-        const newArr = result.forEach(element => {
-          newArr.push(element._id);
-        });
+        const documentIds = result.map(element => element._id);
 
-        setDocumentsIds(newArr);
+        setDocumentsIds(documentIds);
       },
       onFailure: () => {
         console.log("sending user to errorpage");
@@ -74,7 +74,6 @@ function ListView({ currentDBId, setDocumentsIds }) {
 }
 
 ListView.propTypes = {
-  currentDBId: PropTypes.string.isRequired,
   setDocumentsIds: PropTypes.func.isRequired,
 };
 

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateDBModal";
 
-function NoDatabase({ user, setCurrentDBId }) {
+function NoDatabase({ setCurrentDBId }) {
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return (
@@ -24,7 +24,6 @@ function NoDatabase({ user, setCurrentDBId }) {
       </div>
       {showCreateDBModal && (
         <CreateDBModal
-          user={user}
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
         />
@@ -34,7 +33,7 @@ function NoDatabase({ user, setCurrentDBId }) {
 }
 
 NoDatabase.propTypes = {
-  user: PropTypes.string.isRequired,
+  setCurrentDBId: PropTypes.func.isRequired,
 };
 
 export default NoDatabase;

--- a/src/context/CurrentDBIdContext.jsx
+++ b/src/context/CurrentDBIdContext.jsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const CurrentDBIdContext = createContext("");
+
+export default CurrentDBIdContext;

--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const UserContext = createContext("");
+
+export default UserContext;

--- a/src/utils/axios.js
+++ b/src/utils/axios.js
@@ -1,13 +1,13 @@
 import axios from "axios";
 
-const baseUrl = import.meta.env.VITE_API_KEY;
+const baseURL = import.meta.env.VITE_BASE_URL;
 
 function fetchData(method, url, data) {
   const response = axios({
     method,
     url,
     data,
-    baseUrl,
+    baseURL,
     withCredentials: true,
   });
 


### PR DESCRIPTION
### description

- App이 가진 user와 currentDBId state의 광범위하고 깊은 prop inherit을 손쉽게 하기위하여 useContext를 도입하였습니다.
- useContext로 분리하는 선정기준은 state변경시 Header, Sidebar, Content 세가지 섹션이 모두 리렌더가 되어야하는가? 로 정하였습니다.
- axios.js 내부 로직에 오류가 있어 올바르게 수정했습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.
