### PR TITLE
Feat. let Header and Sidebar to react to different circumstances

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -23,6 +23,9 @@ function App() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [isOnSave, setIsOnSave] = useState(false);
   const [isInitial, setIsInitial] = useState(true);
+  const [currentDBName, setCurrentDBName] = useState("");
+
+  const navigate = useNavigate();
 
   const { isLoading } = useQuery(["authStatus"], authUser, {
     retry: false,
@@ -62,16 +65,19 @@ function App() {
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
               setIsOnSave={setIsOnSave}
+              currentDBName={currentDBName}
             />
           )}
           <div className="flex flex-1">
             {user && (
               <Sidebar
+                isEditMode={isEditMode}
                 setCurrentDBId={setCurrentDBId}
                 setDocumentsIds={setDocumentsIds}
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
                 setCurrentDocIndex={setCurrentDocIndex}
+                setCurrentDBName={setCurrentDBName}
               />
             )}
             <div className="flex grow justify-center">
@@ -108,7 +114,12 @@ function App() {
                   />
                   <Route
                     path="nodatabase"
-                    element={<NoDatabase setCurrentDBId={setCurrentDBId} />}
+                    element={
+                      <NoDatabase
+                        setCurrentDBId={setCurrentDBId}
+                        setCurrentDBName={setCurrentDBName}
+                      />
+                    }
                   />
                 </Route>
                 <Route path="/" element={<Navigate replace to="/login" />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,6 +13,7 @@ function Header({
   documentsIds,
   setDocumentsIds,
   setIsOnSave,
+  currentDBName,
 }) {
   return (
     <div className="flex flex-col w-full h-min-[120px] bg-black-bg">
@@ -22,22 +23,27 @@ function Header({
           src="/assets/dataface_logo.png"
           alt="dataface logo"
         />
-        <h1 className="text-white">Page Name</h1>
+        <h1 className="text-white">{currentDBName}</h1>
         <LogoutButton clickHandleLogout={clickHandleLogout} />
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
-        <Toolbar
-          currentDocIndex={currentDocIndex}
-          setCurrentDocIndex={setCurrentDocIndex}
-          documentsIds={documentsIds}
-          setDocumentsIds={setDocumentsIds}
-        />
-        <SaveButton
-          isEditMode={isEditMode}
-          setIsEditMode={setIsEditMode}
-          setIsOnSave={setIsOnSave}
-        />
+        {currentDBName && (
+          <Toolbar
+            isEditMode={isEditMode}
+            currentDocIndex={currentDocIndex}
+            setCurrentDocIndex={setCurrentDocIndex}
+            documentsIds={documentsIds}
+            setDocumentsIds={setDocumentsIds}
+          />
+        )}
+        {currentDBName && (
+          <SaveButton
+            isEditMode={isEditMode}
+            setIsEditMode={setIsEditMode}
+            setIsOnSave={setIsOnSave}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -11,6 +11,7 @@ import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 
 function DocHandlerButtons({
+  isEditMode,
   currentDocIndex,
   setCurrentDocIndex,
   documentsIds,
@@ -69,31 +70,44 @@ function DocHandlerButtons({
   return (
     <div className="flex items-center">
       <Button
-        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
+        className={`flex justify-center items-center w-8 h-8 mr-1 rounded-md
+        ${isEditMode ? "hover:none" : "hover:bg-dark-grey"}`}
         onClick={() => navigateDown()}
+        disabled={isEditMode}
       >
         <img src="/assets/left_icon.svg" alt="left icon" />
       </Button>
-      <span className="flex justify-center items-center w-20 h-8 mr-1 rounded-md bg-white">
+      <span
+        className={`flex justify-center items-center w-20 h-8 mr-1 rounded-md
+        ${isEditMode ? "bg-dark-grey" : "bg-white"}`}
+      >
         {currentDocIndexShownToUser} / {documentsNum}
       </span>
       <Button
-        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md hover:bg-dark-grey"
+        className={`flex justify-center items-center w-8 h-8 mr-1 rounded-md
+        ${isEditMode ? "hover:none" : "hover:bg-dark-grey"}`}
         onClick={() => navigateUp()}
+        disabled={isEditMode}
       >
         <img src="/assets/right_icon.svg" alt="right icon" />
       </Button>
       <Button
-        className="flex justify-center items-center w-8 h-8 mr-1 rounded-md bg-white hover:bg-yellow"
+        className={`flex justify-center items-center w-8 h-8 mr-1 rounded-md
+          ${
+            isEditMode ? "bg-dark-grey hover:none" : "bg-white hover:bg-yellow"
+          }`}
         onClick={() => {
           setShowAddDocumentModal(true);
         }}
+        disabled={isEditMode}
       >
         <img src="/assets/plus_icon.svg" alt="plus icon" />
       </Button>
       <Button
-        className="flex justify-center items-center w-8 h-8 rounded-md bg-white hover:bg-yellow"
+        className={`flex justify-center items-center w-8 h-8 rounded-md
+        ${isEditMode ? "bg-dark-grey hover:none" : "bg-white hover:bg-yellow"}`}
         onClick={() => setShowDeleteDocumentModal(true)}
+        disabled={isEditMode}
       >
         <img src="/assets/minus_icon.svg" alt="minus icon" />
       </Button>

--- a/src/components/HeaderItems/RelationButton.jsx
+++ b/src/components/HeaderItems/RelationButton.jsx
@@ -1,8 +1,12 @@
 import Button from "../shared/Button";
 
-function RelationButton() {
+function RelationButton({ isEditMode }) {
   return (
-    <Button className="flex flex-row items-center w-[160px] h-9 p-2 rounded-md bg-white hover:bg-yellow active:bg-yellow">
+    <Button
+      className={`flex flex-row items-center w-[160px] h-9 p-2 rounded-md
+      ${isEditMode ? "bg-dark-grey hover:none" : "bg-white hover:bg-yellow"}`}
+      disabled={isEditMode}
+    >
       <img
         className="ml-1"
         src="/assets/relation_icon.svg"

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import Button from "../shared/Button";
 
-function SwitchViewButtons() {
+function SwitchViewButtons({ isEditMode }) {
   const [isListView, setIsListView] = useState(true);
   const navigate = useNavigate();
 
@@ -20,17 +20,25 @@ function SwitchViewButtons() {
   return (
     <div className="flex">
       <Button
-        className={`flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow
-        ${isListView ? "bg-yellow" : "bg-white"}`}
+        className={`flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md
+        ${isListView && isEditMode && "bg-dark-grey"}
+        ${isListView && !isEditMode && "bg-yellow"}
+        ${!isListView && isEditMode && "bg-dark-grey"}
+        ${!isListView && !isEditMode && "bg-white"}`}
         onClick={switchToListView}
+        disabled={isEditMode}
       >
         <img className="ml-1" src="/assets/list_icon.svg" alt="list icon" />
         <span className="w-full">List View</span>
       </Button>
       <Button
-        className={`flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md bg-white hover:bg-yellow active:bg-yellow
-        ${!isListView ? "bg-yellow" : "bg-white"}`}
+        className={`flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md
+        ${!isListView && isEditMode && "bg-dark-grey"}
+        ${!isListView && !isEditMode && "bg-yellow"}
+        ${isListView && isEditMode && "bg-dark-grey"}
+        ${isListView && !isEditMode && "bg-white"}`}
         onClick={switchToDetailView}
+        disabled={isEditMode}
       >
         <img className="ml-1" src="/assets/detail_icon.svg" alt="detail icon" />
         <span className="w-full">Detail View</span>

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -5,6 +5,7 @@ import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 
 function Toolbar({
+  isEditMode,
   currentDocIndex,
   setCurrentDocIndex,
   documentsIds,
@@ -12,14 +13,15 @@ function Toolbar({
 }) {
   return (
     <div className="flex justify-between items-center w-full h-full mr-3 bg-black-bg">
-      <RelationButton />
+      <RelationButton isEditMode={isEditMode} />
       <DocHandlerButtons
+        isEditMode={isEditMode}
         currentDocIndex={currentDocIndex}
         setCurrentDocIndex={setCurrentDocIndex}
         documentsIds={documentsIds}
         setDocumentsIds={setDocumentsIds}
       />
-      <SwitchViewButtons />
+      <SwitchViewButtons isEditMode={isEditMode} />
     </div>
   );
 }

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -6,9 +6,7 @@ import fetchData from "../../../utils/axios";
 
 import UserContext from "../../../context/UserContext";
 import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
-import Label from "../SharedItems/Label";
 import InputWrapper from "../SharedItems/InputWrapper";
-import LabelArea from "../SharedItems/InputsArea";
 
 function AddDocInputList({ updateFieldValue, setFields }) {
   const { userId } = useContext(UserContext);

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -19,7 +19,7 @@ import Button from "../../shared/Button";
 
 import CONSTANT from "../../../constants/constant";
 
-function CreateDBModal({ closeModal, setCurrentDBId }) {
+function CreateDBModal({ closeModal, setCurrentDBId, setCurrentDBName }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useContext(UserContext);
@@ -109,6 +109,7 @@ function CreateDBModal({ closeModal, setCurrentDBId }) {
   const { mutate: fetchDatabaseSave } = useMutation(handleClickSave, {
     onSuccess: result => {
       setCurrentDBId(result.data.newDatabase._id);
+      setCurrentDBName(result.data.newDatabase.name);
 
       queryClient.refetchQueries(["userDbList"]);
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,10 +10,12 @@ import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 
 function Sidebar({
+  isEditMode,
   setCurrentDBId,
   isInitial,
   setIsInitial,
   setCurrentDocIndex,
+  setCurrentDBName,
 }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
@@ -35,6 +37,7 @@ function Sidebar({
       onSuccess: result => {
         if (result.length && isInitial) {
           setCurrentDBId(result[0]._id);
+          setCurrentDBName(result[0].name);
           setIsInitial(false);
         }
       },
@@ -52,6 +55,8 @@ function Sidebar({
   const { mutate: fetchDeleteDB } = useMutation(deleteDatabase, {
     onSuccess: () => {
       setCurrentDBId(databases[0]._id);
+      setCurrentDBName(databases[0].name);
+
       queryClient.refetchQueries(["dbDocumentList"]);
       queryClient.refetchQueries(["userDbList"]);
     },
@@ -73,10 +78,13 @@ function Sidebar({
       return false;
     }
 
-    function switchDatabase(clickedDatabaseId) {
+    function switchDatabase(clickedDBId, clickedDB) {
       setCurrentDocIndex(0);
-      setCurrentDBId(clickedDatabaseId);
+      setCurrentDBId(clickedDBId);
+      setCurrentDBName(clickedDB);
+
       queryClient.refetchQueries(["userDb", "dbDocumentList", "document"]);
+      queryClient.refetchQueries(["userDb", "dbDocumentList"]);
     }
 
     return databases.map(element => {
@@ -84,13 +92,15 @@ function Sidebar({
         <div
           key={element._id}
           className={`
-            flex justify-between items-center w-full hover:bg-grey
-            ${isActive(element._id) ? "bg-yellow" : ""}
+            flex justify-between items-center w-ful
+            ${isActive(element._id) && !isEditMode && "bg-yellow"}
+            ${!isEditMode && "hover:bg-yellow"}
             `}
         >
           <Button
             className="w-full"
-            onClick={() => switchDatabase(element._id)}
+            onClick={() => switchDatabase(element._id, element.name)}
+            disabled={isEditMode}
           >
             <div className="flex">
               <img
@@ -101,7 +111,10 @@ function Sidebar({
               <span>{element.name}</span>
             </div>
           </Button>
-          <Button onClick={() => fetchDeleteDB(element._id)}>
+          <Button
+            onClick={() => fetchDeleteDB(element._id)}
+            disabled={isEditMode}
+          >
             <img className="mr-2" src="/assets/bin_icon.svg" alt="bin icon" />
           </Button>
         </div>
@@ -110,7 +123,10 @@ function Sidebar({
   }
 
   return (
-    <div className="flex flex-col items-center min-w-[250px] p-2 bg-light-grey">
+    <div
+      className={`flex flex-col items-center min-w-[250px] p-2
+      ${isEditMode ? "bg-dark-grey" : "bg-light-grey"}`}
+    >
       <div className="flex flex-col w-full">
         <div className="flex h-10 ml-2 items-center">
           <img className="mr-2" src="/assets/DB_icon.svg" alt="DB icon" />
@@ -120,8 +136,10 @@ function Sidebar({
       </div>
       <div className="flex justify-center">
         <Button
-          className="flex justify-center w-48 text-sm items-center rounded-full text-white bg-black-bg hover:bg-dark-grey"
+          className={`flex justify-center w-48 text-sm items-center rounded-full text-white
+          ${isEditMode ? "hidden" : "bg-black-bg hover:bg-dark-grey"}`}
           onClick={() => setShowCreateDBModal(true)}
+          disabled={isEditMode}
         >
           <img
             className="flex justify-between items-center mr-2 w-4"
@@ -135,6 +153,7 @@ function Sidebar({
         <CreateDBModal
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
+          setCurrentDBName={setCurrentDBName}
         />
       )}
     </div>

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -13,7 +13,7 @@ function FieldList({
       <div
         key={element.fieldName}
         className={`absolute w-[350px]
-          ${isEditMode && isDragging ? "rounded-md drop-shadow-md" : null}
+          ${isEditMode && isDragging && "rounded-md drop-shadow-md"}
         `}
         style={{
           top: `${element.yCoordinate}px`,
@@ -23,7 +23,7 @@ function FieldList({
         <div className="flex w-full p-2">
           <span
             className={`flex justify-end mr-3 w-[100px] select-none
-            ${isEditMode ? "hover:cursor-move" : null}`}
+            ${isEditMode && "hover:cursor-move"}`}
             onMouseDown={event => startDragging(index, event)}
             onMouseUp={() => endDragging(index)}
           >
@@ -31,9 +31,9 @@ function FieldList({
           </span>
           <textarea
             className={`flex w-full h-7 mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
-              isEditMode && !isDragging
-                ? "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
-                : null
+              isEditMode &&
+              !isDragging &&
+              "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
             }`}
             maxLength="15"
             onDoubleClick={() => setIsEditMode(true)}

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -86,7 +86,7 @@ function ListView({
     <div className="flex bg-grey w-full h-full">
       <div
         className={`relative flex bg-white w-full m-2 p-5 drop-shadow-md
-      ${isEditMode ? "ring-4 ring-blue" : null}`}
+      ${isEditMode && "ring-4 ring-blue"}`}
       >
         <table className="border-collapse w-full max-h-20 overflow-y-auto">
           <TableHead fields={documents[0].fields} />

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -59,9 +59,8 @@ function TableBody({
                 <textarea
                   className={`w-full h-full rounded-md disabled: bg-inherit resize-none
                   ${
-                    isEditMode
-                      ? "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
-                      : null
+                    isEditMode &&
+                    "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
                   }`}
                   id={field._id}
                   defaultValue={field.fieldValue}

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateNewDatabase/CreateDBModal";
 
-function NoDatabase({ setCurrentDBId }) {
+function NoDatabase({ setCurrentDBId, setCurrentDBName }) {
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return (
@@ -26,6 +26,7 @@ function NoDatabase({ setCurrentDBId }) {
         <CreateDBModal
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
+          setCurrentDBName={setCurrentDBName}
         />
       )}
     </div>


### PR DESCRIPTION
### description

Header와 Sidebar의 각 element가 상황별로 반응하도록 구현하여 완성하였습니다.

- 헤더:

title - 반응형 전환. - DB 전환, 생성, 삭제시 전환 대응 완료.
relation button - disable 및 css
navigator buttons - disable 및 css
create and delete buttons - disable 및 css
switch buttons - disable 및 css

- 사이드바:

전체 - css
DB 버튼 및 쓰레기통 - disable 및 css

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Jul-29-2023 22-17-50](https://github.com/Team-Dataface/DataFace-client/assets/83858724/ad4b2f37-d26e-4eda-a104-650b58937c5c)
