### PR TITLE
Feat. relation view - static

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -12,7 +12,7 @@ import DetailView from "../components/contents/DetailViewItems/DetailView";
 import Sidebar from "../components/Sidebar";
 import ListView from "../components/contents/ListViewItems/ListView";
 import NoDatabase from "../components/contents/NoDatabase";
-import RelationView from "../components/contents/RelationView";
+import RelationView from "../components/contents/RelationItems/RelationView";
 
 import CONSTANT from "../constants/constant";
 

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -12,6 +12,7 @@ import DetailView from "../components/contents/DetailViewItems/DetailView";
 import Sidebar from "../components/Sidebar";
 import ListView from "../components/contents/ListViewItems/ListView";
 import NoDatabase from "../components/contents/NoDatabase";
+import RelationView from "../components/contents/RelationView";
 
 import CONSTANT from "../constants/constant";
 
@@ -112,6 +113,7 @@ function App() {
                       />
                     }
                   />
+                  <Route path="relation" element={<RelationView />} />
                   <Route
                     path="nodatabase"
                     element={

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -44,7 +44,7 @@ function DocHandlerButtons({
       `users/${userId}/databases/${currentDBId}`,
     );
 
-    return response.data.database.documents;
+    return response.data.database;
   }
 
   const { isLoading } = useQuery(
@@ -54,7 +54,7 @@ function DocHandlerButtons({
       retry: false,
       enabled: !!userId && !!currentDBId,
       onSuccess: result => {
-        setDocumentsNum(result.length);
+        setDocumentsNum(result.documents.length);
       },
       onFailure: () => {
         console.log("sending user to errorpage");

--- a/src/components/HeaderItems/RelationButton.jsx
+++ b/src/components/HeaderItems/RelationButton.jsx
@@ -1,11 +1,16 @@
+import { useNavigate } from "react-router-dom";
+
 import Button from "../shared/Button";
 
 function RelationButton({ isEditMode }) {
+  const navigate = useNavigate();
+
   return (
     <Button
       className={`flex flex-row items-center w-[160px] h-9 p-2 rounded-md
       ${isEditMode ? "bg-dark-grey hover:none" : "bg-white hover:bg-yellow"}`}
       disabled={isEditMode}
+      onClick={() => navigate("/dashboard/relation")}
     >
       <img
         className="ml-1"

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -30,10 +30,10 @@ function ListView({
       `users/${userId}/databases/${currentDBId}`,
     );
 
-    return response.data.database.documents;
+    return response.data.database;
   }
 
-  const { data: documents, isLoading } = useQuery(
+  const { data, isLoading } = useQuery(
     ["dbDocumentList", currentDBId],
     getDocumentsList,
     {
@@ -41,7 +41,7 @@ function ListView({
       onSuccess: result => {
         const documentsId = [];
 
-        const docs = result.map(document => {
+        const docs = result.documents.map(document => {
           documentsId.push(document._id);
           return { documentId: document._id, fields: [] };
         });
@@ -89,9 +89,9 @@ function ListView({
       ${isEditMode && "ring-4 ring-blue"}`}
       >
         <table className="border-collapse w-full max-h-20 overflow-y-auto">
-          <TableHead fields={documents[0].fields} />
+          <TableHead fields={data.documents[0].fields} />
           <TableBody
-            documents={documents}
+            documents={data.documents}
             currentDocIndex={currentDocIndex}
             setCurrentDocIndex={setCurrentDocIndex}
             changedDoc={changedDoc}

--- a/src/components/contents/RelationItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationItems/DatabaseFields.jsx
@@ -1,0 +1,25 @@
+function DatabaseFields({ fields, databaseName }) {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <div className="flex flex-col border-2 rounded-lg items-center w-full mb-2 px-20">
+        <h1 className="flex text-xl font-bold py-2">{databaseName}</h1>
+      </div>
+      <div className="flex flex-col border-2 rounded-lg items-center w-full max-h-60 overflow-y-auto mb-12">
+        <ul className="text-center w-full h-auto">
+          {fields.map((field, index) => (
+            <li
+              key={field._id}
+              className={`border-b-2 border-grey w-full py-1 ${
+                index === fields.length - 1 ? "border-b-0" : ""
+              }`}
+            >
+              {field.fieldName}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default DatabaseFields;

--- a/src/components/contents/RelationItems/RelationView.jsx
+++ b/src/components/contents/RelationItems/RelationView.jsx
@@ -1,13 +1,13 @@
 import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import fetchData from "../../utils/axios";
+import fetchData from "../../../utils/axios";
 
-import UserContext from "../../context/UserContext";
-import CurrentDBIdContext from "../../context/CurrentDBIdContext";
+import UserContext from "../../../context/UserContext";
+import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
-import DatabaseFields from "./RelationItems/DatabaseFields";
-import Button from "../shared/Button";
+import DatabaseFields from "./DatabaseFields";
+import Button from "../../shared/Button";
 
 function RelationView() {
   const { userId } = useContext(UserContext);
@@ -29,7 +29,7 @@ function RelationView() {
       retry: false,
       enabled: !!userId && !!currentDBId,
       onSuccess: result => {
-        console.log(result);
+        // will be added..
       },
       onFailure: () => {
         console.log("sending user to errorpage");

--- a/src/components/contents/RelationView.jsx
+++ b/src/components/contents/RelationView.jsx
@@ -1,0 +1,68 @@
+import { useContext } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import fetchData from "../../utils/axios";
+
+import UserContext from "../../context/UserContext";
+import CurrentDBIdContext from "../../context/CurrentDBIdContext";
+
+import DatabaseFields from "./RelationItems/DatabaseFields";
+import Button from "../shared/Button";
+
+function RelationView() {
+  const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
+
+  async function getDocumentsList() {
+    const response = await fetchData(
+      "GET",
+      `users/${userId}/databases/${currentDBId}`,
+    );
+
+    return response.data.database;
+  }
+
+  const { data, isLoading } = useQuery(
+    ["dbDocumentList", currentDBId],
+    getDocumentsList,
+    {
+      retry: false,
+      enabled: !!userId && !!currentDBId,
+      onSuccess: result => {
+        console.log(result);
+      },
+      onFailure: () => {
+        console.log("sending user to errorpage");
+      },
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  if (isLoading && currentDBId) {
+    return <h1>loading</h1>;
+  }
+
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <DatabaseFields
+        fields={data.documents[0].fields}
+        databaseName={data.name}
+      />
+      <div>
+        <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
+          No Relation Yet.
+        </h1>
+        <Button
+          className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"
+          // onClick={() => {
+          //   setShowCreateDBModal(true);
+          // }}
+        >
+          Start making relation!
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default RelationView;


### PR DESCRIPTION
### [노션 칸반 - 관계도 페이지](https://poised-moon-73b.notion.site/FE-Database-327bc285be104639ad3760cc6c96fe23?pvs=4)

### description


#### 1. 현재 사용자가 생성한 Database 별로 필드들을 보여주며 설정한 관계가 단 하나도 없는경우 관계 생성 마법사를 여는 페이지를 만들었습니다. 
추후 관계 생성 마법사 및 실제 관계 설정이 완료되면 설정된 관계들을 보여주는 기능이 추가될 예정입니다. 

#### 2. refetch 시에 캐싱되는 정보를 맞추기 위해 파일별로 리턴하는 response의 수정이 있었습니다! 

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷 (필요시)
![Jul-30-2023 01-24-57](https://github.com/Team-Dataface/DataFace-client/assets/111283378/091517d4-073f-4f89-b8c8-3b2f3127871e)

