### PR TITLE
Fix. detail view

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -73,7 +73,6 @@ function App() {
               <Sidebar
                 isEditMode={isEditMode}
                 setCurrentDBId={setCurrentDBId}
-                setDocumentsIds={setDocumentsIds}
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
                 setCurrentDocIndex={setCurrentDocIndex}
@@ -106,7 +105,6 @@ function App() {
                         setIsEditMode={setIsEditMode}
                         currentDocIndex={currentDocIndex}
                         setCurrentDocIndex={setCurrentDocIndex}
-                        documentsIds={documentsIds}
                         isOnSave={isOnSave}
                         setIsOnSave={setIsOnSave}
                       />

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -12,12 +12,25 @@ import Content from "../SharedItems/Content";
 import ContentWrapper from "../SharedItems/ContentWrapper";
 import Message from "../SharedItems/Message";
 
-function DeleteDocModal({ closeModal, currentDocIndex, documentsIds }) {
+function DeleteDocModal({
+  closeModal,
+  currentDocIndex,
+  documentsIds,
+  setCurrentDocIndex,
+}) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
   const currentDBId = useContext(CurrentDBIdContext);
 
   async function deleteDocument() {
+    if (documentsIds.length === 1) {
+      alert(
+        "Please ensure that the database contains at least one document before proceeding.",
+      );
+
+      return;
+    }
+
     await fetchData(
       "DELETE",
       `/users/${userId}/databases/${currentDBId}/documents/${documentsIds[currentDocIndex]}`,
@@ -27,6 +40,8 @@ function DeleteDocModal({ closeModal, currentDocIndex, documentsIds }) {
   const { mutate: fetchDeleteDocument } = useMutation(deleteDocument, {
     onSuccess: () => {
       queryClient.refetchQueries(["dbDocumentList"]);
+      setCurrentDocIndex(0);
+      closeModal();
     },
     onFailure: () => {
       console.log("sending user to errorpage");

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -54,8 +54,13 @@ function Sidebar({
 
   const { mutate: fetchDeleteDB } = useMutation(deleteDatabase, {
     onSuccess: () => {
-      setCurrentDBId(databases[0]._id);
-      setCurrentDBName(databases[0].name);
+      if (databases.length === 1) {
+        setCurrentDocIndex(0);
+        setCurrentDBName("");
+      } else {
+        setCurrentDBId(databases[0]._id);
+        setCurrentDBName(databases[0].name);
+      }
 
       queryClient.refetchQueries(["dbDocumentList"]);
       queryClient.refetchQueries(["userDbList"]);

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 function FieldList({
-  docData,
+  document,
   isEditMode,
   updateFieldValue,
   setIsEditMode,
@@ -8,7 +8,7 @@ function FieldList({
   startDragging,
   endDragging,
 }) {
-  return docData.map((element, index) => {
+  return document.fields.map((element, index) => {
     return (
       <div
         key={element.fieldName}

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -43,6 +43,7 @@ function ListView({
 
         const docs = result.map(document => {
           documentsId.push(document._id);
+
           return { documentId: document._id, fields: [] };
         });
 


### PR DESCRIPTION
### description

#### 단일 다큐먼트만 받아오던 Detail 뷰 페이지에서 데이터 베이스 변경시, 원활하게 변경되지 않는 문제가 있어 해당 부분 ListView 혹은 Detail View가 받아온 다큐먼트 리스트를 활용해 렌더링 하는것으로 로직을 변경하였으며 `react-query`의 캐싱을 이용하여 필요 이상의 리소스를 받아오는 일이 없도록 하였습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷 (필요시)
![Jul-30-2023 02-05-10](https://github.com/Team-Dataface/DataFace-client/assets/111283378/a24c3eb1-97ca-4c22-9b33-d11b42a4f472)

