### PR TITLE
Feat. portal list fully working with mockup data

### DIFF
--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -5,8 +5,8 @@ function FieldList({
   updateFieldValue,
   setIsEditMode,
   isDragging,
-  startDragging,
-  endDragging,
+  startDraggingField,
+  endDraggingField,
 }) {
   return document.fields.map((element, index) => {
     return (
@@ -24,8 +24,8 @@ function FieldList({
           <span
             className={`flex justify-end mr-3 w-[100px] select-none
             ${isEditMode && "hover:cursor-move"}`}
-            onMouseDown={event => startDragging(index, event)}
-            onMouseUp={() => endDragging(index)}
+            onMouseDown={event => startDraggingField(index, event)}
+            onMouseUp={() => endDraggingField(index)}
           >
             {element.fieldName}
           </span>

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,0 +1,41 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+
+import PortalFooter from "./PortalFooter";
+import PortalTable from "./PortalTable";
+
+function Portal({
+  foreignDocuments,
+  isDragging,
+  startDraggingPortal,
+  endDraggingPortal,
+  isEditMode,
+  portalStyle,
+  setPortalStyle,
+}) {
+  return (
+    <div
+      className="absolute w-auto"
+      style={{
+        top: `${portalStyle.yCoordinate}px`,
+        left: `${portalStyle.xCoordinate}px`,
+      }}
+      onMouseDown={() => {
+        startDraggingPortal();
+      }}
+      onMouseUp={() => {
+        endDraggingPortal();
+      }}
+    >
+      <div className={`h-[${portalStyle.size}px] overflow-y-scroll border`}>
+        <PortalTable
+          isEditMode={isEditMode}
+          isDragging={isDragging}
+          foreignDocuments={foreignDocuments}
+        />
+      </div>
+      {isEditMode && <PortalFooter setPortalStyle={setPortalStyle} />}
+    </div>
+  );
+}
+
+export default Portal;

--- a/src/components/contents/DetailViewItems/PortalFooter.jsx
+++ b/src/components/contents/DetailViewItems/PortalFooter.jsx
@@ -1,0 +1,31 @@
+import Button from "../../shared/Button";
+
+function PortalFooter({ setPortalStyle }) {
+  return (
+    <div className="flex justify-between w-auto h-auto p-1 bg-black-bg">
+      <div className="flex">
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => setPortalStyle(prev => ({ ...prev, size: 100 }))}
+        >
+          small
+        </Button>
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => setPortalStyle(prev => ({ ...prev, size: 150 }))}
+        >
+          medium
+        </Button>
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => setPortalStyle(prev => ({ ...prev, size: 200 }))}
+        >
+          large
+        </Button>
+      </div>
+      <span className="mx-1 text-white text-xs">수업일지</span>
+    </div>
+  );
+}
+
+export default PortalFooter;

--- a/src/components/contents/DetailViewItems/PortalTable.jsx
+++ b/src/components/contents/DetailViewItems/PortalTable.jsx
@@ -1,0 +1,49 @@
+function PortalTable({ isEditMode, isDragging, foreignDocuments }) {
+  return (
+    <table>
+      <tbody
+        className={`border border-dark-grey
+        ${
+          isEditMode &&
+          isDragging &&
+          "rounded-md drop-shadow-md cursor-move select-none"
+        }
+        `}
+      >
+        <tr className="h-10">
+          {foreignDocuments[0].fields.map(document => {
+            return (
+              <td
+                key={document._id}
+                className="w-[130px] h-10 border border-dark-grey text-center"
+              >
+                <span className="w-full h-full">{document.fieldName}</span>
+              </td>
+            );
+          })}
+        </tr>
+        {foreignDocuments.map((element, index) => {
+          return (
+            <tr
+              key={element._id}
+              className="w-[130px] h-10 border border-dark-grey text-center"
+            >
+              {foreignDocuments[index].fields.map(field => {
+                return (
+                  <td
+                    key={field._id}
+                    className="w-10 h-10 border border-dark-grey"
+                  >
+                    <span className="w-full h-full">{field.fieldValue}</span>
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export default PortalTable;

--- a/src/components/contents/DetailViewItems/foreignDocuments.js
+++ b/src/components/contents/DetailViewItems/foreignDocuments.js
@@ -1,0 +1,104 @@
+const foreignDocuments = [
+  {
+    fields: [
+      {
+        fieldName: "이름",
+        fieldValue: "김유진",
+        _id: "a",
+      },
+      {
+        fieldName: "수업일",
+        fieldValue: "2023.06.07",
+        _id: "b",
+      },
+      {
+        fieldName: "참여학생수",
+        fieldValue: "5",
+        _id: "c",
+      },
+    ],
+    _id: "1234",
+  },
+  {
+    fields: [
+      {
+        fieldName: "이름",
+        fieldValue: "김유진",
+        _id: "d",
+      },
+      {
+        fieldName: "수업일",
+        fieldValue: "2023.07.31",
+        _id: "e",
+      },
+      {
+        fieldName: "참여학생수",
+        fieldValue: "10",
+        _id: "f",
+      },
+    ],
+    _id: "2345",
+  },
+  {
+    fields: [
+      {
+        fieldName: "이름",
+        fieldValue: "김유진",
+        _id: "g",
+      },
+      {
+        fieldName: "수업일",
+        fieldValue: "2023.07.12",
+        _id: "h",
+      },
+      {
+        fieldName: "참여학생수",
+        fieldValue: "14",
+        _id: "i",
+      },
+    ],
+    _id: "0987",
+  },
+  {
+    fields: [
+      {
+        fieldName: "이름",
+        fieldValue: "김유진",
+        _id: "m",
+      },
+      {
+        fieldName: "수업일",
+        fieldValue: "2023.07.29",
+        _id: "n",
+      },
+      {
+        fieldName: "참여학생수",
+        fieldValue: "4",
+        _id: "o",
+      },
+    ],
+    _id: "2375",
+  },
+  {
+    fields: [
+      {
+        fieldName: "이름",
+        fieldValue: "김유진",
+        _id: "p",
+      },
+      {
+        fieldName: "수업일",
+        fieldValue: "2023.08.01",
+        _id: "q",
+      },
+      {
+        fieldName: "참여학생수",
+        fieldValue: "2",
+        _id: "r",
+      },
+    ],
+    _id: "8683",
+  },
+];
+
+export default foreignDocuments;

--- a/src/utils/moveFields.js
+++ b/src/utils/moveFields.js
@@ -1,0 +1,52 @@
+import CONSTANT from "../constants/constant";
+
+const { X_DRAG_ADJUSTMENT, Y_DRAG_ADJUSTMENT } = CONSTANT;
+
+function moveFields(
+  event,
+  isEditMode,
+  isDragging,
+  docData,
+  currentDocIndex,
+  draggedElementIndex,
+  setIsDragging,
+  setDocData,
+) {
+  if (isEditMode && isDragging) {
+    const newArr = [...docData];
+
+    newArr[currentDocIndex].fields[draggedElementIndex].xCoordinate =
+      event.clientX - X_DRAG_ADJUSTMENT;
+    newArr[currentDocIndex].fields[draggedElementIndex].yCoordinate =
+      event.clientY - Y_DRAG_ADJUSTMENT;
+
+    if (event.clientX - X_DRAG_ADJUSTMENT < -1) {
+      newArr[currentDocIndex].fields[draggedElementIndex].xCoordinate = 0;
+    }
+
+    if (event.clientY - Y_DRAG_ADJUSTMENT < -1) {
+      newArr[currentDocIndex].fields[draggedElementIndex].yCoordinate = 0;
+    }
+
+    if (event.clientX - X_DRAG_ADJUSTMENT > 1101) {
+      newArr[currentDocIndex].fields[draggedElementIndex].xCoordinate = 1100;
+    }
+
+    if (event.clientY - Y_DRAG_ADJUSTMENT > 571) {
+      newArr[currentDocIndex].fields[draggedElementIndex].yCoordinate = 570;
+    }
+
+    if (
+      event.clientX - X_DRAG_ADJUSTMENT < -30 ||
+      event.clientX - X_DRAG_ADJUSTMENT > 1130 ||
+      event.clientY - Y_DRAG_ADJUSTMENT < -30 ||
+      event.clientY - Y_DRAG_ADJUSTMENT > 590
+    ) {
+      setIsDragging(false);
+    }
+
+    setDocData(newArr);
+  }
+}
+
+export default moveFields;

--- a/src/utils/movePortal.js
+++ b/src/utils/movePortal.js
@@ -1,0 +1,40 @@
+import CONSTANT from "../constants/constant";
+
+const { X_DRAG_ADJUSTMENT, Y_DRAG_ADJUSTMENT } = CONSTANT;
+
+function movePortal(
+  event,
+  isEditMode,
+  isDragging,
+  portalStyle,
+  setIsDragging,
+  setPortalStyle,
+) {
+  if (isEditMode && isDragging) {
+    const newData = { ...portalStyle };
+
+    newData.xCoordinate = event.clientX - X_DRAG_ADJUSTMENT;
+    newData.yCoordinate = event.clientY - Y_DRAG_ADJUSTMENT;
+
+    if (event.clientX - X_DRAG_ADJUSTMENT < -1) {
+      newData.xCoordinate.xCoordinate = 0;
+    }
+
+    if (event.clientY - Y_DRAG_ADJUSTMENT < -1) {
+      newData.yCoordinate.yCoordinate = 0;
+    }
+
+    if (
+      event.clientX - X_DRAG_ADJUSTMENT < -30 ||
+      event.clientX - X_DRAG_ADJUSTMENT > 1130 ||
+      event.clientY - Y_DRAG_ADJUSTMENT < -30 ||
+      event.clientY - Y_DRAG_ADJUSTMENT > 590
+    ) {
+      setIsDragging(false);
+    }
+
+    setPortalStyle(newData);
+  }
+}
+
+export default movePortal;


### PR DESCRIPTION
### [노션칸반 - Detail View Portal](https://www.notion.so/FE-Detail-view-Portal-699c8d931850428b83d0cd5e75b8d20a?pvs=4)

### description

- portal list 테이블을 목업데이터 기반으로 작성했습니다. (DetailViewItems내부에 목업파일이 별도로 있습니다.)

- 포탈용 drag and drop 함수를 새로 작성하고, 기존의 fields과 별개로 잡고 움직일 수 있도록 로직을 구현했습니다.

- 포탈의 small, medium, large 사이즈 조절이 가능합니다.
-> 차후 UX 테스트를 통해 조정이 있을 수 있음.

- 필드와 값에 관한 documents 데이터 (쿼리 결과):
(현재는 mockUp활용중이므로 state 선언문이 빠져있는 점 참고부탁드립니다)
 const [foreignDocuments, setForeignDocuments] = useState([]);
새로 GET해올때마다 onSuccess내부에서 setForeignDocuments로 데이터 replace.
  
- 스타일에 관한 데이터 (관계도 데이터 내부에 있는 property):
 const [portalStyle, setPortalStyle] = useState([]);
새로 GET해올때마다 onSuccess내부에서 setPortalStyle로 데이터 replace.

### remarks

GET 요청 로직은 차후 별도의 branch에서 mockUp 제거후 추가될 예정.
BE쪽 로직 현재 진행중이므로 토의과정 중 리팩토링이 있을 수 있음.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Jul-31-2023 02-48-43](https://github.com/Team-Dataface/DataFace-client/assets/83858724/393e3195-a706-4056-91bd-345fb593e3e4)


