### PR TITLE
Feat. relation wizard

### DIFF
--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -23,6 +23,7 @@ function Toolbar({
     setIsRelationship(false);
     navigate("/dashboard/listview");
   }
+
   return (
     <>
       <Button

--- a/src/components/Modals/Relationship/RelationshipModal.jsx
+++ b/src/components/Modals/Relationship/RelationshipModal.jsx
@@ -8,9 +8,14 @@ import StepTwo from "./StepTwo";
 import StepThree from "./StepThree";
 import Done from "./Done";
 
-function RelationshipModal({ closeModal }) {
+function RelationshipModal({ closeModal, databaseName }) {
   const [relationshipStep, setRelationshipStep] = useState("start");
-  // const [relationData, setRelationData] = useState(null); //일련의 과정 중 모이는 데이터를 store
+  const [relationData, setRelationData] = useState({
+    primaryFieldId: "",
+    foreignDbId: "",
+    foreignFieldId: "",
+    fieldsToDisplay: "",
+  });
 
   return (
     <Modal onClick={closeModal}>
@@ -19,13 +24,26 @@ function RelationshipModal({ closeModal }) {
           <Start setRelationshipStep={setRelationshipStep} />
         )}
         {relationshipStep === "stepOne" && (
-          <StepOne setRelationshipStep={setRelationshipStep} />
+          <StepOne
+            setRelationshipStep={setRelationshipStep}
+            databaseName={databaseName}
+            relationData={relationData}
+            setRelationData={setRelationData}
+          />
         )}
         {relationshipStep === "stepTwo" && (
-          <StepTwo setRelationshipStep={setRelationshipStep} />
+          <StepTwo
+            setRelationshipStep={setRelationshipStep}
+            relationData={relationData}
+            setRelationData={setRelationData}
+          />
         )}
         {relationshipStep === "stepThree" && (
-          <StepThree setRelationshipStep={setRelationshipStep} />
+          <StepThree
+            setRelationshipStep={setRelationshipStep}
+            relationData={relationData}
+            setRelationData={setRelationData}
+          />
         )}
         {relationshipStep === "Done" && (
           <Done

--- a/src/components/Modals/Relationship/RelationshipModal.jsx
+++ b/src/components/Modals/Relationship/RelationshipModal.jsx
@@ -14,7 +14,8 @@ function RelationshipModal({ closeModal, databaseName }) {
     primaryFieldId: "",
     foreignDbId: "",
     foreignFieldId: "",
-    fieldsToDisplay: "",
+    fieldsToDisplay: [],
+    foreignDb: null,
   });
 
   return (

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -20,7 +20,7 @@ function StepOne({
   setRelationData,
 }) {
   const [targetDatabases, setTargetDatabases] = useState([]);
-  const [iseSelected, setIsSelected] = useState("");
+  const [isSelected, setIsSelected] = useState("");
 
   const { userId } = useContext(UserContext);
   const currentDBId = useContext(CurrentDBIdContext);
@@ -50,7 +50,17 @@ function StepOne({
     return <Loading />;
   }
 
-  function handleOnClick(id) {
+  function handleNextClick() {
+    if (!relationData.foreignDbId) {
+      alert("Please choose database to make relationship!");
+
+      return;
+    }
+
+    setRelationshipStep("stepTwo");
+  }
+
+  function handleDatabaseClick(id) {
     setIsSelected(id);
 
     setRelationData({
@@ -67,7 +77,7 @@ function StepOne({
       </Message>
       <Content>
         <div className="flex flex-col justify-around items-center h-auto w-60">
-          <div className="flex border-2 rounded-lg justify-center items-center w-full p-2">
+          <div className="flex border-2 rounded-lg justify-center items-center w-full p-2 bg-blue bg-opacity-50">
             <p>{databaseName}</p>
           </div>
           <div className="border border-blue border-dashed h-16"></div>
@@ -76,10 +86,10 @@ function StepOne({
               {targetDatabases.map((database, index) => (
                 <li
                   className={`w-full py-1 border-b-2 border-grey
-                  ${iseSelected === database._id ? "bg-yellow" : ""}
+                  ${isSelected === database._id ? "bg-yellow" : ""}
                   ${index === targetDatabases.length - 1 ? "border-b-0" : ""}`}
                   key={database._id}
-                  onClick={() => handleOnClick(database._id)}
+                  onClick={() => handleDatabaseClick(database._id)}
                 >
                   {database.name}
                 </li>
@@ -91,7 +101,7 @@ function StepOne({
       <div className="flex justify-end items-center w-full">
         <Button
           className="w-20 h-8 mt-5 rounded-md ring-2 ring-blue text-blue hover:bg-blue hover:text-white"
-          onClick={() => setRelationshipStep("stepTwo")}
+          onClick={handleNextClick}
         >
           Next
         </Button>

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useState, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -12,6 +10,7 @@ import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
 import Loading from "../../shared/Loading";
+import DatabasesWizard from "./WizardItems/DatabasesWizard";
 
 function StepOne({
   setRelationshipStep,
@@ -20,7 +19,6 @@ function StepOne({
   setRelationData,
 }) {
   const [targetDatabases, setTargetDatabases] = useState([]);
-  const [isSelected, setIsSelected] = useState("");
 
   const { userId } = useContext(UserContext);
   const currentDBId = useContext(CurrentDBIdContext);
@@ -60,15 +58,6 @@ function StepOne({
     setRelationshipStep("stepTwo");
   }
 
-  function handleDatabaseClick(id) {
-    setIsSelected(id);
-
-    setRelationData({
-      ...relationData,
-      foreignDbId: id,
-    });
-  }
-
   return (
     <>
       <Title>Step 1</Title>
@@ -76,27 +65,12 @@ function StepOne({
         <p>Please choose a database that you would like to link with DBNAME</p>
       </Message>
       <Content>
-        <div className="flex flex-col justify-around items-center h-auto w-60">
-          <div className="flex border-2 rounded-lg justify-center items-center w-full p-2 bg-blue bg-opacity-50">
-            <p>{databaseName}</p>
-          </div>
-          <div className="border border-blue border-dashed h-16"></div>
-          <div className="flex flex-col border-2 rounded-lg items-center w-full max-h-[190px] overflow-y-scroll">
-            <ul className="w-full h-auto text-center">
-              {targetDatabases.map((database, index) => (
-                <li
-                  className={`w-full py-1 border-b-2 border-grey
-                  ${isSelected === database._id ? "bg-yellow" : ""}
-                  ${index === targetDatabases.length - 1 ? "border-b-0" : ""}`}
-                  key={database._id}
-                  onClick={() => handleDatabaseClick(database._id)}
-                >
-                  {database.name}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
+        <DatabasesWizard
+          databaseName={databaseName}
+          targetDatabases={targetDatabases}
+          relationData={relationData}
+          setRelationData={setRelationData}
+        />
       </Content>
       <div className="flex justify-end items-center w-full">
         <Button

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -72,7 +72,7 @@ function StepThree({ setRelationshipStep, relationData, setRelationData }) {
             databaseName={targetDb.name}
             relationData={relationData}
             setRelationData={setRelationData}
-            status="portal"
+            databaseType="portal"
           />
         </div>
       </Content>

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -1,16 +1,62 @@
+import { useContext } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import fetchData from "../../../utils/axios";
+
+import UserContext from "../../../context/UserContext";
+import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
+
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
 import Content from "../SharedItems/Content";
+import FieldWizard from "./WizardItems/FieldsWizard";
 
-function StepThree({ setRelationshipStep }) {
+function StepThree({ setRelationshipStep, relationData, setRelationData }) {
+  const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
+
+  const targetDb = relationData.foreignDb;
+
+  async function setRelationShip(updatedRelationData) {
+    await fetchData(
+      "PUT",
+      `/users/${userId}/databases/${currentDBId}/relationships}`,
+      updatedRelationData,
+    );
+  }
+
+  const { mutate: fetchRelationshipUpdate } = useMutation(setRelationShip, {
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  function handleBackClick() {
+    setRelationData({
+      ...relationData,
+      fieldsToDisplay: [],
+    });
+
+    setRelationshipStep("stepTwo");
+  }
+
+  function handleNextClick() {
+    const { foreignDb, ...updatedRelationData } = relationData;
+
+    fetchRelationshipUpdate(updatedRelationData);
+
+    setRelationshipStep("Done");
+  }
+
   return (
     <>
       <Title>Step 3</Title>
       <Message>
         <p>
-          Please choose fields from DBNAME that you would like to display on the
-          portal list
+          {`Please choose fields from ${targetDb.name} that you would like to display on the
+          portal list`}
         </p>
       </Message>
       <Content>
@@ -21,19 +67,25 @@ function StepThree({ setRelationshipStep }) {
           </span>
         </div>
         <div className="flex justify-center items-center h-60 w-60">
-          database fields card here
+          <FieldWizard
+            fields={targetDb.documents[0].fields}
+            databaseName={targetDb.name}
+            relationData={relationData}
+            setRelationData={setRelationData}
+            status="portal"
+          />
         </div>
       </Content>
       <div className="flex justify-between items-center w-full">
         <Button
           className="w-20 h-8 mt-5 rounded-md bg-dark-grey text-white hover:bg-grey"
-          onClick={() => setRelationshipStep("stepTwo")}
+          onClick={handleBackClick}
         >
           Back
         </Button>
         <Button
           className="w-20 h-8 mt-5 rounded-md ring-2 ring-blue text-blue hover:bg-blue hover:text-white"
-          onClick={() => setRelationshipStep("Done")}
+          onClick={handleNextClick}
         >
           Next
         </Button>

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -1,9 +1,77 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { useState, useContext } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import fetchData from "../../../utils/axios";
+
+import UserContext from "../../../context/UserContext";
+import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
+
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
-import Content from "../SharedItems/Content";
+import FieldWizard from "./WizardItems/FieldsWizard";
+import Loading from "../../shared/Loading";
 
-function StepTwo({ setRelationshipStep }) {
+function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
+  const [fieldsName, setFieldsName] = useState({
+    primaryFieldName: "",
+    foreignFieldName: "",
+  });
+
+  const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
+
+  const databases = {};
+
+  async function getDatabaseList() {
+    const response = await fetchData("GET", `users/${userId}/databases`);
+
+    return response.data.databases;
+  }
+
+  const { data, isLoading } = useQuery(["dbs"], getDatabaseList, {
+    enabled: !!userId,
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  function handleBackClick() {
+    setRelationData({
+      ...relationData,
+      primaryFieldId: "",
+      foreignFieldId: "",
+    });
+
+    setRelationshipStep("stepOne");
+  }
+
+  function handleNextClick() {
+    if (!relationData.primaryFieldId || !relationData.foreignFieldId) {
+      alert("Please choose fields to make relationship!");
+
+      return;
+    }
+
+    setRelationshipStep("stepThree");
+  }
+
+  data.forEach(database => {
+    if (database._id === currentDBId) {
+      databases.baseDb = database;
+    }
+    if (database._id === relationData.foreignDbId) {
+      databases.targetDb = database;
+    }
+  });
+
   return (
     <>
       <Title>Step 2</Title>
@@ -12,30 +80,51 @@ function StepTwo({ setRelationshipStep }) {
           Please choose one field from each Database that you would like to link
         </p>
       </Message>
-      <Content>
-        <div className="flex justify-center items-center h-60 w-60">
-          database fields card here
+      {databases && (
+        <div className="flex justify-center items-center">
+          <FieldWizard
+            fields={databases.baseDb.documents[0].fields}
+            databaseName={databases.baseDb.name}
+            relationData={relationData}
+            setRelationData={setRelationData}
+            fieldsName={fieldsName}
+            setFieldsName={setFieldsName}
+            status="base"
+          />
+          <div
+            className={`border border-dashed w-40 h-0 mb-10 ${
+              relationData.primaryFieldId && relationData.foreignFieldId
+                ? "border-blue"
+                : "border-white"
+            }`}
+          ></div>
+          <FieldWizard
+            fields={databases.targetDb.documents[0].fields}
+            databaseName={databases.targetDb.name}
+            relationData={relationData}
+            setRelationData={setRelationData}
+            fieldsName={fieldsName}
+            setFieldsName={setFieldsName}
+            status="target"
+          />
         </div>
-        <div className="flex justify-center items-center h-60 w-60">
-          database fields card here
-        </div>
-      </Content>
+      )}
       <Message>
         <p>
-          Documents within DBNAME will be automatically queried and displayed
+          {`Documents within ${databases.targetDb.name} will be automatically queried and displayed`}
         </p>
-        <p>based on the match between the NAME field and the NAME field</p>
+        <p>{`based on the match between the ${fieldsName.primaryFieldName} field and the ${fieldsName.foreignFieldName} field`}</p>
       </Message>
       <div className="flex justify-between items-center w-full">
         <Button
           className="w-20 h-8 mt-5 rounded-md bg-dark-grey text-white hover:bg-grey"
-          onClick={() => setRelationshipStep("stepOne")}
+          onClick={handleBackClick}
         >
           Back
         </Button>
         <Button
           className="w-20 h-8 mt-5 rounded-md ring-2 ring-blue text-blue hover:bg-blue hover:text-white"
-          onClick={() => setRelationshipStep("stepThree")}
+          onClick={handleNextClick}
         >
           Next
         </Button>

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -55,7 +55,7 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
 
   function handleNextClick() {
     if (!relationData.primaryFieldId || !relationData.foreignFieldId) {
-      alert("Please choose fields to make relationship!");
+      alert("Please choose fields to procceed");
 
       return;
     }
@@ -94,7 +94,7 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
             setRelationData={setRelationData}
             fieldsName={fieldsName}
             setFieldsName={setFieldsName}
-            status="base"
+            databaseType="base"
           />
           <div className="flex items-center h-[160px] my-10">
             <div
@@ -112,7 +112,7 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
             setRelationData={setRelationData}
             fieldsName={fieldsName}
             setFieldsName={setFieldsName}
-            status="target"
+            databaseType="target"
           />
         </div>
       )}

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -60,6 +60,11 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
       return;
     }
 
+    setRelationData({
+      ...relationData,
+      foreignDb: databases.targetDb,
+    });
+
     setRelationshipStep("stepThree");
   }
 
@@ -81,7 +86,7 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
         </p>
       </Message>
       {databases && (
-        <div className="flex justify-center items-center">
+        <div className="flex justify-center items-start h-full">
           <FieldWizard
             fields={databases.baseDb.documents[0].fields}
             databaseName={databases.baseDb.name}
@@ -91,13 +96,15 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
             setFieldsName={setFieldsName}
             status="base"
           />
-          <div
-            className={`border border-dashed w-40 h-0 mb-10 ${
-              relationData.primaryFieldId && relationData.foreignFieldId
-                ? "border-blue"
-                : "border-white"
-            }`}
-          ></div>
+          <div className="flex items-center h-[160px] my-10">
+            <div
+              className={`border border-dashed w-40 h-0 mb-10 ${
+                relationData.primaryFieldId && relationData.foreignFieldId
+                  ? "border-blue"
+                  : "border-white"
+              }`}
+            ></div>
+          </div>
           <FieldWizard
             fields={databases.targetDb.documents[0].fields}
             databaseName={databases.targetDb.name}

--- a/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
@@ -1,0 +1,47 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { useState } from "react";
+
+function DatabasesWizard({
+  databaseName,
+  targetDatabases,
+  relationData,
+  setRelationData,
+}) {
+  const [isSelected, setIsSelected] = useState("");
+
+  function handleDatabaseClick(id) {
+    setIsSelected(id);
+
+    setRelationData({
+      ...relationData,
+      foreignDbId: id,
+    });
+  }
+
+  return (
+    <div className="flex flex-col justify-around items-center w-60 h-auto">
+      <div className="flex justify-center items-center w-full p-2 border-2 rounded-lg bg-blue bg-opacity-50">
+        <p>{databaseName}</p>
+      </div>
+      <div className="border border-blue border-dashed h-16"></div>
+      <div className="flex flex-col items-center w-full max-h-[190px] border-2 rounded-lg overflow-y-scroll">
+        <ul className="w-full h-auto text-center">
+          {targetDatabases.map((database, index) => (
+            <li
+              className={`w-full py-1 border-b-2 border-grey
+              ${isSelected === database._id ? "bg-yellow" : ""}
+              ${index === targetDatabases.length - 1 ? "border-b-0" : ""}`}
+              key={database._id}
+              onClick={() => handleDatabaseClick(database._id)}
+            >
+              {database.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default DatabasesWizard;

--- a/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
@@ -1,0 +1,84 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import { useState } from "react";
+
+function FieldWizard({
+  fields,
+  databaseName,
+  relationData,
+  setRelationData,
+  fieldsName,
+  setFieldsName,
+  status,
+}) {
+  const [isSelected, setIsSelected] = useState("");
+  const [updatedFields, setUpdatedFields] = useState(fields);
+
+  function moveToFirstIndex(id) {
+    const selectedFieldIndex = updatedFields.findIndex(
+      field => field._id === id,
+    );
+
+    if (selectedFieldIndex !== -1) {
+      const updatedFieldsCopy = [...updatedFields];
+      const selectedField = updatedFieldsCopy.splice(selectedFieldIndex, 1)[0];
+
+      updatedFieldsCopy.unshift(selectedField);
+      setUpdatedFields(updatedFieldsCopy);
+    }
+  }
+
+  function handleOnClick(id, name) {
+    if (status === "base") {
+      setRelationData({
+        ...relationData,
+        primaryFieldId: id,
+      });
+
+      setFieldsName({
+        ...fieldsName,
+        primaryFieldName: name,
+      });
+    }
+
+    if (status === "target") {
+      setRelationData({
+        ...relationData,
+        foreignFieldId: id,
+      });
+
+      setFieldsName({
+        ...fieldsName,
+        foreignFieldName: name,
+      });
+    }
+
+    setIsSelected(id);
+    moveToFirstIndex(id);
+  }
+
+  return (
+    <div className="flex flex-col justify-center items-center w-[160px] my-10">
+      <div className="flex flex-col w-full mb-2 border-2 rounded-md items-center bg-blue bg-opacity-50">
+        <span className="flex font-bold py-1">{databaseName}</span>
+      </div>
+      <div className="flex flex-col items-center w-full max-h-[120px] border-2 rounded-md overflow-y-scroll">
+        <ul className="w-full h-auto text-center">
+          {updatedFields.map((field, index) => (
+            <li
+              key={field._id}
+              onClick={() => handleOnClick(field._id, field.fieldName)}
+              className={`w-full py-1 border-b-2 border-grey
+              ${isSelected === field._id ? "bg-yellow" : ""}
+              ${index === updatedFields.length - 1 ? "border-b-0" : ""}`}
+            >
+              {field.fieldName}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default FieldWizard;

--- a/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
@@ -13,8 +13,13 @@ function FieldWizard({
 }) {
   const [isSelected, setIsSelected] = useState("");
   const [updatedFields, setUpdatedFields] = useState(fields);
+  const [selectedFields, setSelectedFields] = useState([]);
 
   function moveToFirstIndex(id) {
+    if (status === "portal") {
+      return;
+    }
+
     const selectedFieldIndex = updatedFields.findIndex(
       field => field._id === id,
     );
@@ -39,6 +44,8 @@ function FieldWizard({
         ...fieldsName,
         primaryFieldName: name,
       });
+
+      setIsSelected(id);
     }
 
     if (status === "target") {
@@ -51,9 +58,32 @@ function FieldWizard({
         ...fieldsName,
         foreignFieldName: name,
       });
+
+      setIsSelected(id);
     }
 
-    setIsSelected(id);
+    if (status === "portal") {
+      setSelectedFields(prevSelectedFields =>
+        prevSelectedFields.includes(id)
+          ? prevSelectedFields.filter(selectedId => selectedId !== id)
+          : [...prevSelectedFields, id],
+      );
+
+      if (!relationData.fieldsToDisplay.includes(id)) {
+        setRelationData({
+          ...relationData,
+          fieldsToDisplay: [...relationData.fieldsToDisplay, id],
+        });
+      } else {
+        setRelationData({
+          ...relationData,
+          fieldsToDisplay: relationData.fieldsToDisplay.filter(
+            fieldId => fieldId !== id,
+          ),
+        });
+      }
+    }
+
     moveToFirstIndex(id);
   }
 
@@ -69,6 +99,7 @@ function FieldWizard({
               key={field._id}
               onClick={() => handleOnClick(field._id, field.fieldName)}
               className={`w-full py-1 border-b-2 border-grey
+              ${selectedFields.includes(field._id) ? "bg-yellow" : ""}
               ${isSelected === field._id ? "bg-yellow" : ""}
               ${index === updatedFields.length - 1 ? "border-b-0" : ""}`}
             >

--- a/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
@@ -9,14 +9,14 @@ function FieldWizard({
   setRelationData,
   fieldsName,
   setFieldsName,
-  status,
+  databaseType,
 }) {
   const [isSelected, setIsSelected] = useState("");
   const [updatedFields, setUpdatedFields] = useState(fields);
   const [selectedFields, setSelectedFields] = useState([]);
 
   function moveToFirstIndex(id) {
-    if (status === "portal") {
+    if (databaseType === "portal") {
       return;
     }
 
@@ -34,7 +34,7 @@ function FieldWizard({
   }
 
   function handleOnClick(id, name) {
-    if (status === "base") {
+    if (databaseType === "base") {
       setRelationData({
         ...relationData,
         primaryFieldId: id,
@@ -48,7 +48,7 @@ function FieldWizard({
       setIsSelected(id);
     }
 
-    if (status === "target") {
+    if (databaseType === "target") {
       setRelationData({
         ...relationData,
         foreignFieldId: id,
@@ -62,7 +62,7 @@ function FieldWizard({
       setIsSelected(id);
     }
 
-    if (status === "portal") {
+    if (databaseType === "portal") {
       setSelectedFields(prevSelectedFields =>
         prevSelectedFields.includes(id)
           ? prevSelectedFields.filter(selectedId => selectedId !== id)

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -9,11 +9,13 @@ import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import DatabaseFields from "./DatabaseFields";
 import Button from "../../shared/Button";
 import RelationshipModal from "../../Modals/Relationship/RelationshipModal";
+import Loading from "../../shared/Loading";
 
 function Relationship() {
+  const [showRelationshipModal, setShowRelationshipModal] = useState(false);
+
   const { userId } = useContext(UserContext);
   const currentDBId = useContext(CurrentDBIdContext);
-  const [showRelationshipModal, setShowRelationshipModal] = useState(false);
 
   async function getDocumentsList() {
     const response = await fetchData(
@@ -40,8 +42,8 @@ function Relationship() {
     },
   );
 
-  if (isLoading && currentDBId) {
-    return <h1>loading</h1>;
+  if (isLoading) {
+    return <Loading />;
   }
 
   return (
@@ -50,7 +52,7 @@ function Relationship() {
         fields={data.documents[0].fields}
         databaseName={data.name}
       />
-      <div>
+      <div className="flex flex-col items-center">
         <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
           No Relationship Yet.
         </h1>
@@ -65,6 +67,7 @@ function Relationship() {
         {showRelationshipModal && (
           <RelationshipModal
             closeModal={() => setShowRelationshipModal(false)}
+            databaseName={data.name}
           />
         )}
       </div>


### PR DESCRIPTION
### [노션 칸반 - 관계 설정 마법사](https://poised-moon-73b.notion.site/FE-Database-072ee7d0101e4463b831347d8dcfae3e?pvs=4)

### description

#### 사용자가 생성한 Database들 간에 관계를 설정할 수 있도록 도와주는 마법사 기능을 구현 하였습니다. 
1. 최초 화면을 열면 현재 Database를 제외한 나머지 Database들이 목록에 나오며 선택이 가능합니다. 
선택하지 않으면 다음으로 넘어 갈 수 없습니다. 

2. 현재 database와 선택한 database가 나오며 필드들이 나열됩니다. 

3. 나열된 필드들을 하나씩 선택 가능하며 선택하는 필드가 배열의 최상단에 나옵니다. 
둘다 선택하지 않으면 다음으로 넘어 갈 수 없습니다.

4. 포탈에 보여줄 필드들을 선택합니다. 

5. 클릭으로 선택과 취소가 가능하며, 다중 선택이 가능합니다. 

서버에 보내는 요청 로직까지 작성 해놓았으나, 아직 서버 로직이 머지가 되지 않은 관계로 실제 데이터와 상이하면 변경이 있을 수 있습니다!

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷
![Jul-31-2023 04-52-22](https://github.com/Team-Dataface/DataFace-client/assets/111283378/298f75f7-b616-4824-a7df-1dae6dafc739)

