### PR TITLE
Fix. fix query function to reset query

### DIFF
--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -58,7 +58,7 @@ function AddDocumentModal({
         addNewDocumentId(result);
         setCurrentDocIndex(documentsIds.length);
 
-        queryClient.refetchQueries(["dbDocumentList"]);
+        queryClient.refetchQueries(["dbDocumentList", currentDBId]);
         closeModal();
       },
       onFailure: () => {

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -42,7 +42,7 @@ function DeleteDocModal({
     deleteDocument,
     {
       onSuccess: () => {
-        queryClient.refetchQueries(["dbDocumentList"]);
+        queryClient.refetchQueries(["dbDocumentList", currentDBId]);
         setCurrentDocIndex(0);
         closeModal();
       },

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -52,20 +52,24 @@ function Sidebar({
   );
 
   async function deleteDatabase(databaseId) {
-    await fetchData("DELETE", `/users/${userId}/databases/${databaseId}`);
+    const response = await fetchData(
+      "DELETE",
+      `/users/${userId}/databases/${databaseId}`,
+    );
+
+    return response.data.databases;
   }
 
   const { mutate: fetchDeleteDB } = useMutation(deleteDatabase, {
-    onSuccess: () => {
+    onSuccess: result => {
       if (databases.length === 1) {
         setCurrentDocIndex(0);
         setCurrentDBName("");
       } else {
-        setCurrentDBId(databases[0]._id);
-        setCurrentDBName(databases[0].name);
+        setCurrentDBId(result[0]._id);
+        setCurrentDBName(result[0].name);
       }
 
-      queryClient.refetchQueries(["dbDocumentList"]);
       queryClient.refetchQueries(["userDbList"]);
     },
     onFailure: () => {
@@ -91,8 +95,7 @@ function Sidebar({
       setCurrentDBId(clickedDBId);
       setCurrentDBName(clickedDB);
 
-      queryClient.refetchQueries(["userDb", "dbDocumentList", "document"]);
-      queryClient.refetchQueries(["userDb", "dbDocumentList"]);
+      queryClient.refetchQueries(["userDbList"]);
     }
 
     return databases.map(element => {

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -75,7 +75,7 @@ function DetailView({
 
   const { mutate: fetchDocumentUpdate } = useMutation(handleClickSave, {
     onSuccess: () => {
-      queryClient.refetchQueries(["dbDocumentList"]);
+      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
     },
     onFailure: () => {
       console.log("sending user to errorpage");

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -35,7 +35,7 @@ function ListView({
     return response.data.database;
   }
 
-  const { data, isLoading } = useQuery(
+  const { data, isLoading: isQueryLoading } = useQuery(
     ["dbDocumentList", currentDBId],
     getDocumentsList,
     {
@@ -68,7 +68,7 @@ function ListView({
 
   const { mutate: fetchDocumentUpdate } = useMutation(handleClickSave, {
     onSuccess: () => {
-      queryClient.refetchQueries(["dbDocumentList"]);
+      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
     },
     onFailure: () => {
       console.log("sending user to errorpage");
@@ -76,7 +76,7 @@ function ListView({
     refetchOnWindowFocus: false,
   });
 
-  const loadingTimeout = useLoading(isLoading);
+  const loadingTimeout = useLoading(isQueryLoading);
 
   if (loadingTimeout) {
     return <Loading />;

--- a/src/utils/useLoading.js
+++ b/src/utils/useLoading.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-function useLoading(isReactQueryLoading, delay = 200) {
+function useLoading(isQueryLoading, delay = 1000) {
   const [isLoadingTimeout, setIsLoadingTimeout] = useState(false);
 
   useEffect(() => {
@@ -11,7 +11,7 @@ function useLoading(isReactQueryLoading, delay = 200) {
     return () => clearTimeout(timeoutId);
   }, [delay]);
 
-  const isLoadingCombined = isReactQueryLoading || !isLoadingTimeout;
+  const isLoadingCombined = isQueryLoading || !isLoadingTimeout;
 
   return isLoadingCombined;
 }


### PR DESCRIPTION
### [노션 - 칸반 FE 에러 핸들링](https://poised-moon-73b.notion.site/FrontEnd-09a58fc7cc594739a91f71faaa1ebe53?pvs=4)

### description
유저 친화적 에러 핸들링을 위하여 개발 단계에서 빈번하게 일어나던 GET 요청 에러를 수정하였습니다. 
기존 `refetchQuery` 를 이용하여 다시 페칭하던 쿼리함수에서 이전 DatabaseId 값을 참조해 서버로부터 404 에러를 전달 받던 이슈가 있어 
이 부분을 개선하였습니다. 

최초 resetQuery로 메소드를 변경하여 아예 다시 쿼리를 요청해오는 방향으로 로직을 작성하였으나, 이는 불필요하게 서버에게 많은 fetching을 요청한다고 판단하여 refetchQuery를 다시 학습 및 적용하였습니다.

기존 쿼리 함수 `queryClient.refetchQueries(["dbDocumentList"]);` 
--- >
변경된 쿼리 함수 `queryClient.refetchQueries(["dbDocumentList", currentDBId]);`

이로 인해 현재 데이터 베이스 아이디를 참조할 수 있습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.
