### PR TITLE
Feat. type validation and textarea customization on detail view

### DIFF
--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -21,6 +21,7 @@ function Toolbar({
 
   function clickHandelBackButton() {
     setIsRelationship(false);
+    setIsListView(true);
     navigate("/dashboard/listview");
   }
 

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -47,10 +47,18 @@ function AddDocInputList({ updateFieldValue, setFields }) {
           {element.fieldName}
         </span>
         <InputWrapper>
-          <textarea
-            className="flex w-full h-7 rounded-md text-center"
-            onChange={event => updateFieldValue(index, event)}
-          />
+          {element.fieldType === "Text" ? (
+            <textarea
+              className="flex w-full h-7 rounded-md text-center"
+              onChange={event => updateFieldValue(index, event)}
+            />
+          ) : (
+            <input
+              className="flex w-full h-7 rounded-md text-center"
+              type={element.fieldType}
+              onChange={event => updateFieldValue(index, event)}
+            />
+          )}
         </InputWrapper>
       </div>
     );

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -28,10 +28,17 @@ function AddDocumentModal({
 
   const [fields, setFields] = useState([]);
 
+  function adjustTextareaHeight(event) {
+    event.target.style.height = `${event.target.scrollHeight}px`;
+  }
+
   function updateFieldValue(index, event) {
     const newArr = [...fields];
+
     newArr[index].fieldValue = event.target.value;
+
     setFields(newArr);
+    adjustTextareaHeight(event);
   }
 
   function addNewDocumentId(newId) {

--- a/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
@@ -27,7 +27,8 @@ function CreateDBInputList({
             />
             <Select
               options={FIELD_TYPES}
-              onChange={event => updateFieldType(index, event)}
+              updateFieldType={updateFieldType}
+              index={index}
             />
             <Button
               className="flex justify-center items-center"

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -94,6 +94,7 @@ function Sidebar({
       setCurrentDocIndex(0);
       setCurrentDBId(clickedDBId);
       setCurrentDBName(clickedDB);
+      setIsListView(true);
 
       queryClient.refetchQueries(["userDbList"]);
     }

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -112,6 +112,14 @@ function DetailView({
     setDocData(newArr);
   }
 
+  function updateFieldRows(index, value) {
+    const newArr = [...docData];
+
+    newArr[currentDocIndex].fields[index].rows = value;
+
+    setDocData(newArr);
+  }
+
   function startDraggingPortal() {
     setIsDragging(true);
     setDraggedElementIndex("portal");
@@ -170,6 +178,7 @@ function DetailView({
               document={docData[currentDocIndex]}
               isEditMode={isEditMode}
               updateFieldValue={updateFieldValue}
+              updateFieldRows={updateFieldRows}
               setIsEditMode={setIsEditMode}
               isDragging={isDragging}
               startDraggingField={startDraggingField}

--- a/src/components/contents/DetailViewItems/FieldFooter.jsx
+++ b/src/components/contents/DetailViewItems/FieldFooter.jsx
@@ -1,0 +1,30 @@
+import Button from "../../shared/Button";
+
+function FieldFooter({ index, updateFieldRows }) {
+  return (
+    <div className="flex justify-between w-auto h-auto p-1 bg-black-bg">
+      <div className="flex">
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => updateFieldRows(index, 1)}
+        >
+          small
+        </Button>
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => updateFieldRows(index, 4)}
+        >
+          medium
+        </Button>
+        <Button
+          className="flex items-center w-auto h-4 mr-1 p-2 bg-white text-xs"
+          onClick={() => updateFieldRows(index, 8)}
+        >
+          large
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default FieldFooter;

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -35,7 +35,7 @@ function FieldList({
           {element.fieldType === "Text" ? (
             <div className="flex flex-col w-full">
               <textarea
-                className={`flex w-full mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-nonee ${
+                className={`flex w-full mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
                   isEditMode &&
                   !isDragging &&
                   "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -1,3 +1,5 @@
+import FieldFooter from "./FieldFooter";
+
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 function FieldList({
   document,
@@ -7,20 +9,21 @@ function FieldList({
   isDragging,
   startDraggingField,
   endDraggingField,
+  updateFieldRows,
 }) {
   return document.fields.map((element, index) => {
     return (
       <div
         key={element.fieldName}
         className={`absolute w-[350px]
-          ${isEditMode && isDragging && "rounded-md drop-shadow-md"}
+          ${isEditMode && isDragging && "drop-shadow-md"}
         `}
         style={{
           top: `${element.yCoordinate}px`,
           left: `${element.xCoordinate}px`,
         }}
       >
-        <div className="flex w-full p-2">
+        <div className="flex w-full h-full p-2">
           <span
             className={`flex justify-end mr-3 w-[100px] select-none
             ${isEditMode && "hover:cursor-move"}`}
@@ -29,18 +32,38 @@ function FieldList({
           >
             {element.fieldName}
           </span>
-          <textarea
-            className={`flex w-full h-7 mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
-              isEditMode &&
-              !isDragging &&
-              "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
-            }`}
-            maxLength="15"
-            onDoubleClick={() => setIsEditMode(true)}
-            onChange={event => updateFieldValue(index, event)}
-            value={element.fieldValue}
-            readOnly={!isEditMode}
-          />
+          {element.fieldType === "Text" ? (
+            <div className="flex flex-col w-full">
+              <textarea
+                className={`flex w-full mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-nonee ${
+                  isEditMode &&
+                  !isDragging &&
+                  "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+                }`}
+                rows={element.rows}
+                onDoubleClick={() => setIsEditMode(true)}
+                onChange={event => updateFieldValue(index, event)}
+                value={element.fieldValue}
+                readOnly={!isEditMode}
+              />
+              {isEditMode && (
+                <FieldFooter index={index} updateFieldRows={updateFieldRows} />
+              )}
+            </div>
+          ) : (
+            <input
+              className={`flex w-full mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
+                isEditMode &&
+                !isDragging &&
+                "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+              }`}
+              type={element.fieldType}
+              onDoubleClick={() => setIsEditMode(true)}
+              onChange={event => updateFieldValue(index, event)}
+              value={element.fieldValue}
+              readOnly={!isEditMode}
+            />
+          )}
         </div>
       </div>
     );

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -12,7 +12,6 @@ function TableBody({
 }) {
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;
-    console.log("worked");
   }
 
   useEffect(() => {

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 function TableBody({
   documents,
   currentDocIndex,
@@ -8,6 +10,19 @@ function TableBody({
   setIsEditMode,
   isEditMode,
 }) {
+  function adjustTextareaHeight(event) {
+    event.target.style.height = `${event.target.scrollHeight}px`;
+    console.log("worked");
+  }
+
+  useEffect(() => {
+    const textareas = document.querySelectorAll(".auto-resize");
+
+    textareas.forEach(textarea => {
+      adjustTextareaHeight({ target: textarea });
+    });
+  }, [documents]);
+
   function handleOnChange(event, documentId) {
     const { id, value } = event.target;
     const newChangedDoc = [...changedDoc];
@@ -30,8 +45,7 @@ function TableBody({
     }
 
     setChangedDoc(newChangedDoc);
-
-    event.target.style.height = `${event.target.scrollHeight}px`;
+    adjustTextareaHeight(event);
   }
 
   return (
@@ -56,17 +70,33 @@ function TableBody({
               className="h-full border"
             >
               <div className="h-auto pt-2 px-3">
-                <textarea
-                  className={`w-full h-full rounded-md disabled: bg-inherit resize-none
-                  ${
-                    isEditMode &&
-                    "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
-                  }`}
-                  id={field._id}
-                  defaultValue={field.fieldValue}
-                  disabled={!isEditMode}
-                  onChange={event => handleOnChange(event, document._id)}
-                ></textarea>
+                {field.fieldType === "Text" ? (
+                  <textarea
+                    className={`w-full rounded-md disabled: bg-inherit resize-none auto-resize
+                    ${
+                      isEditMode &&
+                      "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+                    }`}
+                    id={field._id}
+                    rows="1"
+                    defaultValue={field.fieldValue}
+                    disabled={!isEditMode}
+                    onChange={event => handleOnChange(event, document._id)}
+                  />
+                ) : (
+                  <input
+                    className={`w-full h-full rounded-md disabled: bg-inherit resize-none
+                    ${
+                      isEditMode &&
+                      "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"
+                    }`}
+                    id={field._id}
+                    type={field.fieldType}
+                    defaultValue={field.fieldValue}
+                    disabled={!isEditMode}
+                    onChange={event => handleOnChange(event, document._id)}
+                  />
+                )}
               </div>
             </td>
           ))}

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -1,8 +1,11 @@
 import PropTypes from "prop-types";
 
-function Select({ options }) {
+function Select({ options, updateFieldType, index }) {
   return (
-    <select className="flex items-center w-[140px] h-7 mr-2 p-1 px-2 bg-light-grey text-center">
+    <select
+      className="flex items-center w-[140px] h-7 mr-2 p-1 px-2 bg-light-grey text-center"
+      onChange={event => updateFieldType(index, event)}
+    >
       {options.map(option => (
         <option key={option} value={option}>
           {option}

--- a/src/constants/constant.js
+++ b/src/constants/constant.js
@@ -1,12 +1,5 @@
 const CONSTANT = {
-  FIELD_TYPES: [
-    "Text",
-    "Number",
-    "Date",
-    "Time",
-    "Date created",
-    "Date modified",
-  ],
+  FIELD_TYPES: ["Text", "Date", "Time", "Date created", "Date modified"],
   MAX_DATABASE_NAME_LENGTH: 15,
   MAX_FIELD_NAME_LENGTH: 20,
   ONE_HOUR_IN_MILLISECONDS: 1000 * 60 * 60,


### PR DESCRIPTION
### [노션 칸반 - type 적용 & 유효성검사](https://www.notion.so/FE-input-type-f118e6f92f0649149f290f821499bed9?pvs=4)

### description

#### switch buttons
- detail view를 보고 있는 와중 relationship페이지에 갔다가 돌아왔을 때 detailview에 계속해서 active불이 들어와있는 것을 수정.
- detail view를 보고 있는 와중 sidebar에서 DB를 전환할때 detailview에 계속해서 active불이 들어와있는 것을 수정.

#### Number type삭제

- Number는 각종 연산과 total amount 등의 기능 확장 위한 타입이나, 현 단계에서 개발계획이 없기 때문에 제거하였습니다.
(토의완료내용)

#### 입력창에 사용자 정의 Type을 적용

- DB에서 받아오는 각 field의 type에 따라서 "Text"는 `<textarea>`를, 그 외에는 `<input>`을 렌더하도록 하였습니다.

- input에는 렌더와 동시에 type에 fieldType을 적용했습니다. 

- document생성 모달에서도 똑같이 Type적용 완료했습니다.

- ListView에서 textarea의 내부 값이 길 경우, 자동으로 initial render시 길이조정을 하여 보여지도록 하였습니다.

#### detailView에서의 textarea 크기 사용자정의 기능

- DetailVeiw의 textarea의 경우는, 값의 길이에 따라 높이가 유동적이여서는 안됩니다.
그러나 height속성을 적용할 수 없는 점 때문에 rows방식을 택했습니다.
portal에 이미 적용중인 small / medium / large를 적용하여 각각 1, 4, 8줄로 커스터마이즈가 가능하도록 하였습니다.
rows데이터는 Save시 다른 x, y좌표와함께 DB로 보내져, 페이지를 이탈하고 다시 접속하더라도 textarea의 사이즈가 유지됩니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

![Jul-31-2023 18-48-05](https://github.com/Team-Dataface/DataFace-client/assets/83858724/3abde556-46f7-482e-9972-eb996a5544e9)

![Jul-31-2023 18-55-37](https://github.com/Team-Dataface/DataFace-client/assets/83858724/7d13000d-afff-4273-a6da-eee96586650a)


