### PR TITLE
Feat. relationship view

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,7 +27,7 @@ function Header({
           src="/assets/dataface_logo.png"
           alt="dataface logo"
         />
-        <h1 className="text-white">{currentDBName}</h1>
+        <span className="text-white">{currentDBName}</span>
         <LogoutButton clickHandleLogout={clickHandleLogout} />
       </div>
 

--- a/src/components/Modals/Relationship/Done.jsx
+++ b/src/components/Modals/Relationship/Done.jsx
@@ -1,9 +1,16 @@
+import { useContext } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
+import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 function Done({ closeModal }) {
+  const queryClient = useQueryClient();
+  const currentDBId = useContext(CurrentDBIdContext);
+
   return (
     <>
       <Title>Done!</Title>
@@ -16,7 +23,11 @@ function Done({ closeModal }) {
       </Content>
       <Button
         className="w-20 h-8 mt-5 rounded-md bg-black-bg text-white hover:bg-dark-grey"
-        onClick={closeModal}
+        onClick={() => {
+          queryClient.refetchQueries(["dbDocumentList", currentDBId]);
+          queryClient.refetchQueries(["dbRelationShips", currentDBId]);
+          closeModal();
+        }}
       >
         Close
       </Button>

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -48,7 +48,6 @@ function StepThree({ setRelationshipStep, relationData, setRelationData }) {
     const { foreignDb, ...updatedRelationData } = relationData;
 
     fetchRelationshipUpdate(updatedRelationData);
-
     setRelationshipStep("Done");
   }
 

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -49,7 +49,6 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
   }
 
   function handleNextClick() {
-    console.log(relationData);
     if (!relationData.primaryFieldName || !relationData.foreignFieldName) {
       alert("Please choose fields to procceed");
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -96,7 +96,8 @@ function Sidebar({
       setCurrentDBName(clickedDB);
       setIsListView(true);
 
-      queryClient.refetchQueries(["userDbList"]);
+      queryClient.refetchQueries(["userDb"]);
+      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
     }
 
     return databases.map(element => {

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -15,9 +15,9 @@ function NoDatabase({
   return (
     <div className="flex flex-col justify-center">
       <div className="flex flex-col justiy-center items-center">
-        <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[3rem]">
+        <span className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[3rem]">
           No Database yet.
-        </h1>
+        </span>
         <Button
           className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"
           onClick={() => {

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -1,28 +1,76 @@
-function DatabaseFields({ fields, databaseName }) {
-  const keyFieldMockUp = {
-    _id: "64c6126162fa40107897593",
-    fieldName: "test1",
-  };
+/* eslint-disable no-else-return */
+import { useState } from "react";
+
+function DatabaseFields({
+  fields,
+  databaseName,
+  primaryDbId,
+  databaseId,
+  dbIndex,
+  relationships,
+}) {
+  const [fieldNames, setFieldNames] = useState([]);
+  const [updatedFields, setUpdatedFields] = useState(() => {
+    if (primaryDbId === databaseId) {
+      const primaryFieldNames = relationships.map(
+        relation => relation.primaryFieldName,
+      );
+      const updatedFieldsCopy = fields.filter(
+        field => !primaryFieldNames.includes(field.fieldName),
+      );
+      const primaryField = fields.filter(field =>
+        primaryFieldNames.includes(field.fieldName),
+      );
+
+      primaryField.forEach(fieldNmae => updatedFieldsCopy.unshift(fieldNmae));
+
+      setFieldNames(primaryFieldNames);
+
+      return updatedFieldsCopy;
+    }
+
+    const relation = relationships.find(
+      item => item.foreignDbId === databaseId,
+    );
+    const { foreignFieldName, foreignDbId } = relation;
+
+    const selectedFieldIndex = fields.findIndex(
+      field =>
+        field.fieldName === foreignFieldName && databaseId === foreignDbId,
+    );
+
+    if (selectedFieldIndex !== -1) {
+      const updatedFieldsCopy = [...fields];
+      const selectedField = updatedFieldsCopy.splice(selectedFieldIndex, 1)[0];
+
+      updatedFieldsCopy.unshift(selectedField);
+
+      return updatedFieldsCopy;
+    } else {
+      return fields;
+    }
+  });
 
   return (
-    <div className="flex flex-col justify-center items-center w-[160px] m-10">
+    <div
+      className={`flex flex-col justify-center items-center w-72
+      ${primaryDbId === databaseId ? "rounded-md p-1" : ""} ${
+        primaryDbId === databaseId ? "border-4 border-blue" : ""
+      }
+      ${databaseId !== primaryDbId && dbIndex === 0 ? "mt-8" : ""}`}
+    >
       <div className="flex flex-col w-full mb-2 border-2 rounded-md items-center bg-blue bg-opacity-50">
         <span className="flex font-bold py-1">{databaseName}</span>
       </div>
-      <div className="flex flex-col items-center w-full max-h-[190px] border-2 rounded-md overflow-y-scroll">
+      <div className="flex flex-col items-center w-full max-h-56 border-2 rounded-md overflow-y-scroll">
         <ul className="w-full h-auto text-center">
-          <li
-            className={`w-full py-1 border-b-2 bg-yellow border-grey
-          ${!keyFieldMockUp && "hidden"}`}
-          >
-            {keyFieldMockUp.fieldName}
-          </li>
-          {fields.map((field, index) => (
+          {updatedFields?.map((field, index) => (
             <li
               key={field._id}
-              className={`w-full py-1 border-b-2 border-grey ${
-                index === fields.length - 1 ? "border-b-0" : ""
-              }`}
+              className={`w-full py-1 border-b-2 border-grey
+              ${fieldNames.includes(field.fieldName) ? "bg-yellow" : ""}
+              ${index === 0 ? "bg-yellow" : ""}
+              ${index === fields.length - 1 ? "border-b-0" : ""}`}
             >
               {field.fieldName}
             </li>

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -1,5 +1,12 @@
 /* eslint-disable no-else-return */
-import { useState } from "react";
+import { useState, useContext } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetchData from "../../../utils/axios";
+
+import UserContext from "../../../context/UserContext";
+import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
+import Button from "../../shared/Button";
 
 function DatabaseFields({
   fields,
@@ -9,7 +16,12 @@ function DatabaseFields({
   dbIndex,
   relationships,
 }) {
+  const queryClient = useQueryClient();
+  const { userId } = useContext(UserContext);
+  const currentDBId = useContext(CurrentDBIdContext);
+
   const [fieldNames, setFieldNames] = useState([]);
+  const [relationId, setRelationId] = useState("");
   const [updatedFields, setUpdatedFields] = useState(() => {
     if (primaryDbId === databaseId) {
       const primaryFieldNames = relationships.map(
@@ -32,12 +44,16 @@ function DatabaseFields({
     const relation = relationships.find(
       item => item.foreignDbId === databaseId,
     );
-    const { foreignFieldName, foreignDbId } = relation;
+    const foreignFieldName = relation?.foreignFieldName;
+    const foreignDbId = relation?.foreignDbId;
+    const _id = relation?._id;
 
     const selectedFieldIndex = fields.findIndex(
       field =>
         field.fieldName === foreignFieldName && databaseId === foreignDbId,
     );
+
+    setRelationId(_id);
 
     if (selectedFieldIndex !== -1) {
       const updatedFieldsCopy = [...fields];
@@ -51,17 +67,44 @@ function DatabaseFields({
     }
   });
 
+  async function deleteRelationship() {
+    await fetchData(
+      "DELETE",
+      `/users/${userId}/databases/${currentDBId}/relationships/${relationId}`,
+    );
+  }
+
+  const { mutate: fetchDeleteRelationship } = useMutation(deleteRelationship, {
+    onSuccess: () => {
+      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
+      queryClient.refetchQueries(["dbRelationShips", currentDBId]);
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+  });
+
   return (
     <div
-      className={`flex flex-col justify-center items-center w-72
-      ${primaryDbId === databaseId ? "rounded-md p-1" : ""} ${
-        primaryDbId === databaseId ? "border-4 border-blue" : ""
+      className={`relative group flex flex-col justify-center items-center w-72 mb-20
+      ${primaryDbId === databaseId ? "rounded-md p-1" : ""}
+      ${primaryDbId === databaseId ? "ring-4 ring-blue" : ""}
+      ${primaryDbId !== databaseId ? "hover:rounded-md p-1" : ""}
+      ${primaryDbId !== databaseId ? "hover:ring-4 ring-red" : ""}
       }
       ${databaseId !== primaryDbId && dbIndex === 0 ? "mt-8" : ""}`}
     >
       <div className="flex flex-col w-full mb-2 border-2 rounded-md items-center bg-blue bg-opacity-50">
         <span className="flex font-bold py-1">{databaseName}</span>
       </div>
+      <Button
+        className={`absolute -top-3 -right-3 flex w-6 h-6 hidden ${
+          primaryDbId !== databaseId ? "group-hover:block" : ""
+        }`}
+        onClick={fetchDeleteRelationship}
+      >
+        <img className="" src="/assets/close_icon.svg" alt="close button" />
+      </Button>
       <div className="flex flex-col items-center w-full max-h-56 border-2 rounded-md overflow-y-scroll">
         <ul className="w-full h-auto text-center">
           {updatedFields?.map((field, index) => (

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -78,7 +78,6 @@ function Relationship() {
 
   // eslint-disable-next-line consistent-return
   useMemo(() => {
-    console.log(123444);
     if (documentQuery.data && relationQuery.data) {
       const newDb = [documentQuery.data, ...relationQuery.data];
 
@@ -89,8 +88,6 @@ function Relationship() {
   if (documentQuery.isLoading) {
     return <Loading />;
   }
-
-  // console.log(documents);
 
   return (
     <div className="flex flex-col w-full justify-center items-center">

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -13,6 +13,8 @@ import Loading from "../../shared/Loading";
 
 function Relationship() {
   const [showRelationshipModal, setShowRelationshipModal] = useState(false);
+  const [docs, setDocs] = useState([]);
+  const [relationships, setRelationships] = useState([]);
 
   const { userId } = useContext(UserContext);
   const currentDBId = useContext(CurrentDBIdContext);
@@ -62,6 +64,9 @@ function Relationship() {
         queryFn: getDocumentsList,
         enabled: !!userId && !!currentDBId,
         refetchOnWindowFocus: false,
+        onSuccess: result => {
+          setRelationships(result.relationships);
+        },
       },
       {
         queryKey: ["dbRelationShips", currentDBId],
@@ -72,21 +77,25 @@ function Relationship() {
   });
 
   // eslint-disable-next-line consistent-return
-  const documents = useMemo(() => {
+  useMemo(() => {
+    console.log(123444);
     if (documentQuery.data && relationQuery.data) {
       const newDb = [documentQuery.data, ...relationQuery.data];
-      return sortDatabses(newDb);
+
+      setDocs(sortDatabses(newDb));
     }
   }, [documentQuery.data, relationQuery.data]);
 
-  if (documentQuery.isLoading || relationQuery.isLoading) {
+  if (documentQuery.isLoading) {
     return <Loading />;
   }
+
+  // console.log(documents);
 
   return (
     <div className="flex flex-col w-full justify-center items-center">
       <div className="flex flex-row w-full justify-center items-start">
-        {documents?.map((database, index) => (
+        {docs?.map((database, index) => (
           <div className="flex flex-row mb-10" key={database._id}>
             <DatabaseFields
               key={crypto.randomUUID()}
@@ -95,12 +104,12 @@ function Relationship() {
               primaryDbId={currentDBId}
               databaseId={database._id}
               dbIndex={index}
-              relationships={documentQuery.data.relationships}
+              relationships={relationships}
             />
-            {documents.length === 2 && index === 0 && (
+            {docs.length === 2 && index === 0 && (
               <div className="border border-dashed w-80 h-0 mt-16 border-blue"></div>
             )}
-            {documents.length === 3 && (index === 0 || index === 1) && (
+            {docs.length === 3 && (index === 0 || index === 1) && (
               <div
                 className={`border border-dashed w-80 h-0 border-blue ${
                   index === 0 ? "mt-24" : "mt-16"
@@ -111,7 +120,7 @@ function Relationship() {
         ))}
       </div>
       <div className="flex flex-col items-center">
-        {documents.length === 1 && (
+        {docs.length === 1 && (
           <span className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
             No Relationship Yet.
           </span>

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -38,7 +38,7 @@ function Relationship() {
   }
 
   // eslint-disable-next-line consistent-return
-  function sortDatabses(array) {
+  function sortDatabases(array) {
     const { length } = array;
     const primaryDbIndex = array.findIndex(item => item._id === currentDBId);
 
@@ -81,7 +81,7 @@ function Relationship() {
     if (documentQuery.data && relationQuery.data) {
       const newDb = [documentQuery.data, ...relationQuery.data];
 
-      setDocs(sortDatabses(newDb));
+      setDocs(sortDatabases(newDb));
     }
   }, [documentQuery.data, relationQuery.data]);
 

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -1,5 +1,5 @@
-import { useContext, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useContext, useState, useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
 
 import fetchData from "../../../utils/axios";
 
@@ -26,36 +26,96 @@ function Relationship() {
     return response.data.database;
   }
 
-  const { data, isLoading } = useQuery(
-    ["dbDocumentList", currentDBId],
-    getDocumentsList,
-    {
-      retry: false,
-      enabled: !!userId && !!currentDBId,
-      onSuccess: result => {
-        // will be added..
-      },
-      onFailure: () => {
-        console.log("sending user to errorpage");
-      },
-      refetchOnWindowFocus: false,
-    },
-  );
+  async function getRelationships() {
+    const response = await fetchData(
+      "GET",
+      `users/${userId}/databases/${currentDBId}/relationships`,
+    );
 
-  if (isLoading) {
+    return response.data.foreignDatabases;
+  }
+
+  // eslint-disable-next-line consistent-return
+  function sortDatabses(array) {
+    const { length } = array;
+    const primaryDbIndex = array.findIndex(item => item._id === currentDBId);
+
+    if (length === 1) {
+      return array;
+    }
+    if (length === 2) {
+      const newDatabases = primaryDbIndex === 0 ? [array[0], array[1]] : array;
+
+      return newDatabases;
+    }
+    if (length === 3) {
+      const newDatabases = [array[1], array[primaryDbIndex], array[2]];
+
+      return newDatabases;
+    }
+  }
+
+  const [documentQuery, relationQuery] = useQueries({
+    queries: [
+      {
+        queryKey: ["dbDocumentList", currentDBId],
+        queryFn: getDocumentsList,
+        enabled: !!userId && !!currentDBId,
+        refetchOnWindowFocus: false,
+      },
+      {
+        queryKey: ["dbRelationShips", currentDBId],
+        queryFn: getRelationships,
+        refetchOnWindowFocus: false,
+      },
+    ],
+  });
+
+  // eslint-disable-next-line consistent-return
+  const documents = useMemo(() => {
+    if (documentQuery.data && relationQuery.data) {
+      const newDb = [documentQuery.data, ...relationQuery.data];
+      return sortDatabses(newDb);
+    }
+  }, [documentQuery.data, relationQuery.data]);
+
+  if (documentQuery.isLoading || relationQuery.isLoading) {
     return <Loading />;
   }
 
   return (
-    <div className="flex flex-col justify-center items-center">
-      <DatabaseFields
-        fields={data.documents[0].fields}
-        databaseName={data.name}
-      />
+    <div className="flex flex-col w-full justify-center items-center">
+      <div className="flex flex-row w-full justify-center items-start">
+        {documents?.map((database, index) => (
+          <div className="flex flex-row mb-10" key={database._id}>
+            <DatabaseFields
+              key={crypto.randomUUID()}
+              fields={database.documents[0].fields}
+              databaseName={database.name}
+              primaryDbId={currentDBId}
+              databaseId={database._id}
+              dbIndex={index}
+              relationships={documentQuery.data.relationships}
+            />
+            {documents.length === 2 && index === 0 && (
+              <div className="border border-dashed w-80 h-0 mt-16 border-blue"></div>
+            )}
+            {documents.length === 3 && (index === 0 || index === 1) && (
+              <div
+                className={`border border-dashed w-80 h-0 border-blue ${
+                  index === 0 ? "mt-24" : "mt-16"
+                }`}
+              ></div>
+            )}
+          </div>
+        ))}
+      </div>
       <div className="flex flex-col items-center">
-        <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
-          No Relationship Yet.
-        </h1>
+        {documents.length === 1 && (
+          <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
+            No Relationship Yet.
+          </h1>
+        )}
         <Button
           className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"
           onClick={() => {
@@ -67,7 +127,7 @@ function Relationship() {
         {showRelationshipModal && (
           <RelationshipModal
             closeModal={() => setShowRelationshipModal(false)}
-            databaseName={data.name}
+            databaseName={documentQuery.data.name}
           />
         )}
       </div>

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -112,9 +112,9 @@ function Relationship() {
       </div>
       <div className="flex flex-col items-center">
         {documents.length === 1 && (
-          <h1 className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
+          <span className="flex justify-center items-center mb-12 font-bold text-dark-grey text-[2rem]">
             No Relationship Yet.
-          </h1>
+          </span>
         )}
         <Button
           className="w-[250px] h-[30px] rounded-md bg-black-bg text-white hover:bg-dark-grey"


### PR DESCRIPTION
### [노션 칸반 - 관계도 시각화 ](https://poised-moon-73b.notion.site/FE-Database-327bc285be104639ad3760cc6c96fe23?pvs=4)

### description

기존 목업 상태로 머물러 있던 관계도 시각화 페이지에 본격적인 기능을 추가 했습니다. 
1. 설정된 관계에 따라 메인 데이터 베이스를 기준으로 우측 혹은 양 옆으로 관계가 설정된 카드들이 나오도록 구현 하였습니다.
2. 메인 데이터 베이스는 파란색 테두리로 표시 되게끔 하였습니다.
3. 삭제 기능이 있어, 마우스를 올리면 빨간 테두리가 생기며 삭제 버튼이 생기도록 하였습니다.
4. 삭제 버튼 클릭시, 관계가 삭제되며 화면이 업데이트 되도록 하였습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷
![Aug-01-2023 23-34-45](https://github.com/Team-Dataface/DataFace-client/assets/111283378/1bc2620b-ee0c-42b5-abd8-43098add77cd)


