### PR TITLE
Feat. errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.10",
         "react-router-dom": "^6.14.2"
       },
       "devDependencies": {
@@ -13262,6 +13263,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.10.tgz",
+      "integrity": "sha512-pvVKdi77j2OoPHo+p3rorgE43OjDWiqFkaqkJz8sJKK6uf/u8xtzuaVfj5qJ2JnDLIgF1De3zY5AJDijp+LVPA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.10",
     "react-router-dom": "^6.14.2"
   },
   "lint-staged": {

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
 
 import UserContext from "../context/UserContext";
 import CurrentDBIdContext from "../context/CurrentDBIdContext";
@@ -14,6 +15,7 @@ import ListView from "../components/contents/ListViewItems/ListView";
 import NoDatabase from "../components/contents/NoDatabase";
 import Relationship from "../components/contents/RelationshipItems/Relationship";
 import Loading from "../components/shared/Loading";
+import ErrorPage from "../components/shared/ErrorPage";
 
 import CONSTANT from "../constants/constant";
 
@@ -57,95 +59,97 @@ function App() {
   }
 
   return (
-    <UserContext.Provider value={user}>
-      <CurrentDBIdContext.Provider value={currentDBId}>
-        <div className="flex flex-col h-screen">
-          {user && (
-            <Header
-              clickHandleLogout={setUser}
-              isEditMode={isEditMode}
-              setIsEditMode={setIsEditMode}
-              currentDocIndex={currentDocIndex}
-              setCurrentDocIndex={setCurrentDocIndex}
-              documentsIds={documentsIds}
-              setDocumentsIds={setDocumentsIds}
-              setIsOnSave={setIsOnSave}
-              currentDBName={currentDBName}
-              isRelationship={isRelationship}
-              setIsRelationship={setIsRelationship}
-              isListView={isListView}
-              setIsListView={setIsListView}
-            />
-          )}
-          <div className="flex flex-1">
+    <ErrorBoundary FallbackComponent={ErrorPage}>
+      <UserContext.Provider value={user}>
+        <CurrentDBIdContext.Provider value={currentDBId}>
+          <div className="flex flex-col h-screen">
             {user && (
-              <Sidebar
+              <Header
+                clickHandleLogout={setUser}
                 isEditMode={isEditMode}
-                setCurrentDBId={setCurrentDBId}
-                isInitial={isInitial}
-                setIsInitial={setIsInitial}
-                setCurrentDocIndex={setCurrentDocIndex}
-                setCurrentDBName={setCurrentDBName}
-                isRelationship={isRelationship}
-                setIsListView={setIsListView}
+                setIsEditMode={setIsEditMode}
                 currentDocIndex={currentDocIndex}
-                setRelationshipsData={setRelationshipsData}
+                setCurrentDocIndex={setCurrentDocIndex}
+                documentsIds={documentsIds}
+                setDocumentsIds={setDocumentsIds}
+                setIsOnSave={setIsOnSave}
+                currentDBName={currentDBName}
+                isRelationship={isRelationship}
+                setIsRelationship={setIsRelationship}
+                isListView={isListView}
+                setIsListView={setIsListView}
               />
             )}
-            <div className="flex grow justify-center">
-              <Routes>
-                <Route path="/login" element={<Login setUser={setUser} />} />
-                <Route path="/dashboard" element={<ContentsContainer />}>
-                  <Route
-                    path="listview"
-                    element={
-                      <ListView
-                        isEditMode={isEditMode}
-                        setIsEditMode={setIsEditMode}
-                        currentDocIndex={currentDocIndex}
-                        setCurrentDocIndex={setCurrentDocIndex}
-                        setDocumentsIds={setDocumentsIds}
-                        isOnSave={isOnSave}
-                        setIsOnSave={setIsOnSave}
-                      />
-                    }
-                  />
-                  <Route
-                    path="detailview"
-                    element={
-                      <DetailView
-                        isEditMode={isEditMode}
-                        setIsEditMode={setIsEditMode}
-                        currentDocIndex={currentDocIndex}
-                        setCurrentDocIndex={setCurrentDocIndex}
-                        setDocumentsIds={setDocumentsIds}
-                        isOnSave={isOnSave}
-                        setIsOnSave={setIsOnSave}
-                        relationshipsData={relationshipsData}
-                        setRelationshipsData={setRelationshipsData}
-                      />
-                    }
-                  />
-                  <Route path="relationship" element={<Relationship />} />
-                  <Route
-                    path="nodatabase"
-                    element={
-                      <NoDatabase
-                        setCurrentDBId={setCurrentDBId}
-                        setCurrentDBName={setCurrentDBName}
-                        isListView={isListView}
-                        setIsListView={setIsListView}
-                      />
-                    }
-                  />
-                </Route>
-                <Route path="/" element={<Navigate replace to="/login" />} />
-              </Routes>
+            <div className="flex flex-1">
+              {user && (
+                <Sidebar
+                  isEditMode={isEditMode}
+                  setCurrentDBId={setCurrentDBId}
+                  isInitial={isInitial}
+                  setIsInitial={setIsInitial}
+                  setCurrentDocIndex={setCurrentDocIndex}
+                  setCurrentDBName={setCurrentDBName}
+                  isRelationship={isRelationship}
+                  setIsListView={setIsListView}
+                  currentDocIndex={currentDocIndex}
+                  setRelationshipsData={setRelationshipsData}
+                />
+              )}
+              <div className="flex grow justify-center">
+                <Routes>
+                  <Route path="/login" element={<Login setUser={setUser} />} />
+                  <Route path="/dashboard" element={<ContentsContainer />}>
+                    <Route
+                      path="listview"
+                      element={
+                        <ListView
+                          isEditMode={isEditMode}
+                          setIsEditMode={setIsEditMode}
+                          currentDocIndex={currentDocIndex}
+                          setCurrentDocIndex={setCurrentDocIndex}
+                          setDocumentsIds={setDocumentsIds}
+                          isOnSave={isOnSave}
+                          setIsOnSave={setIsOnSave}
+                        />
+                      }
+                    />
+                    <Route
+                      path="detailview"
+                      element={
+                        <DetailView
+                          isEditMode={isEditMode}
+                          setIsEditMode={setIsEditMode}
+                          currentDocIndex={currentDocIndex}
+                          setCurrentDocIndex={setCurrentDocIndex}
+                          setDocumentsIds={setDocumentsIds}
+                          isOnSave={isOnSave}
+                          setIsOnSave={setIsOnSave}
+                          relationshipsData={relationshipsData}
+                          setRelationshipsData={setRelationshipsData}
+                        />
+                      }
+                    />
+                    <Route path="relationship" element={<Relationship />} />
+                    <Route
+                      path="nodatabase"
+                      element={
+                        <NoDatabase
+                          setCurrentDBId={setCurrentDBId}
+                          setCurrentDBName={setCurrentDBName}
+                          isListView={isListView}
+                          setIsListView={setIsListView}
+                        />
+                      }
+                    />
+                  </Route>
+                  <Route path="/" element={<Navigate replace to="/login" />} />
+                </Routes>
+              </div>
             </div>
           </div>
-        </div>
-      </CurrentDBIdContext.Provider>
-    </UserContext.Provider>
+        </CurrentDBIdContext.Provider>
+      </UserContext.Provider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/shared/ErrorPage.jsx
+++ b/src/components/shared/ErrorPage.jsx
@@ -1,0 +1,39 @@
+import { useNavigate } from "react-router-dom";
+
+import Button from "./Button";
+
+function ErrorPage({ error }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex items-center justify-around w-full min-h-screen">
+      <div className="flex flex-col justify-center h-full">
+        <p className="text-xl">Error Code: {error.status}</p>
+        <p className="text-xl mb-8">
+          {error ? error.message : "An unexpected error occurred."}
+        </p>
+        <h1 className="text-8xl text-red mb-16">Oops!</h1>
+        <p className="text-xl mb-8">Here are some helpful Links instead</p>
+        <div className="flex justify-between mt-6">
+          <Button
+            className="px-4 py-2 text-white bg-red rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400"
+            onClick={() => navigate("/login")}
+          >
+            <span>Login</span>
+          </Button>
+          <Button
+            className="px-4 py-2 text-white bg-red rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400"
+            onClick={() => window.location.reload()}
+          >
+            <span>Retry</span>
+          </Button>
+        </div>
+      </div>
+      <div>
+        <p>Error image will be here</p>
+      </div>
+    </div>
+  );
+}
+
+export default ErrorPage;


### PR DESCRIPTION
### [노션 칸반 - FE 에러 핸들링](https://poised-moon-73b.notion.site/FrontEnd-09a58fc7cc594739a91f71faaa1ebe53?pvs=4)

### description
자식 컴포넌트들에서 에러가 발생하면 에러 페이지를 표시해주는 Error Boundary의 도입 및 초안을 작성 했습니다. 
기존 react의 Error - boundary는 함수형 컴포넌트가 아닌 class형 컴포넌트로만 선언이 가능하여 이를 따라 class로 구현 하려 하였으나 공식 문서에서 react-error-boundary 라이브러리를 도입해도 된다고 하여 이에 따라 라이브러리를 도입하여 기초만 작성 해놓은 상태입니다! 
[reat error boundary github](https://github.com/bvaughn/react-error-boundary)
<br></br>
[공식문서 에러 바운더리 링크](https://react-ko.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
![스크린샷 2023-08-02 오후 8 13 56](https://github.com/Team-Dataface/DataFace-client/assets/111283378/67eb4cb0-2566-4740-8ce7-5b3af334916c)



### concern

현재 컴포넌트 내부에서 발생하는 에러는 잘 catch하나 기본적으로 비동기로 발생하는 에러는 catch 못하는 상황입니다. 
자세히 이야기 해보자면 
제가 기대한 흐름은 다음과 같습니다.
- 비동기로 인한 서버 에러 발생 --> 서버에서 에러 코드 및 메시지 전달 --> 이를 기반으로 에러 페이지 렌더링 

그러나 현재 비동기에서 발생하는 에러를 잡지 못하고 있어 아래와 같은 흐름으로 진행되고 있어 이 부분 리팩토링이 필요할듯 합니다! 
- 비동기로 인한 서버 에러 발생 --> 서버에서 에러 코드 및 메시지 전달 --> 해당 에러는 잡히지 않고 이로 인해 선언되지 못한 변수들 값이 undefined 라는 에러 메시지와 함께 에러 페이지 렌더링 
![스크린샷 2023-08-02 오후 8 09 40](https://github.com/Team-Dataface/DataFace-client/assets/111283378/30c7e9d9-6a09-4964-bdc9-0e438fe47cdd)


그러나 이 이외에 다른 에러는 잘 잡아주고 있습니다! 

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷 

![스크린샷 2023-08-02 오후 8 09 25](https://github.com/Team-Dataface/DataFace-client/assets/111283378/b4a6761c-6fb3-4855-a487-51e5c7946711)

