### PR TITLE
Feat. add Date modified & created feature at FE

### DIFF
--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
+import getTodaysDate from "../../../utils/getTodaysDate";
 
 import UserContext from "../../../context/UserContext";
 import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
@@ -37,15 +38,6 @@ function AddDocInputList({ updateFieldValue, setFields }) {
     return <Loading />;
   }
 
-  function updateDateModified() {
-    const today = new Date();
-    const year = today.getFullYear();
-    const month = String(today.getMonth() + 1).padStart(2, "0");
-    const day = String(today.getDate()).padStart(2, "0");
-
-    return `${year}/${month}/${day}`;
-  }
-
   return data.fields.map((element, index) => {
     return (
       <div key={element._id} className="flex w-[500px]">
@@ -69,7 +61,7 @@ function AddDocInputList({ updateFieldValue, setFields }) {
               defaultValue={
                 element.fieldType === "Date modified" ||
                 element.fieldType === "Date created"
-                  ? updateDateModified()
+                  ? getTodaysDate()
                   : ""
               }
               disabled={

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -43,7 +43,7 @@ function AddDocInputList({ updateFieldValue, setFields }) {
     const month = String(today.getMonth() + 1).padStart(2, "0");
     const day = String(today.getDate()).padStart(2, "0");
 
-    return `${year}-${month}-${day}`;
+    return `${year}/${month}/${day}`;
   }
 
   return data.fields.map((element, index) => {

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -37,6 +37,15 @@ function AddDocInputList({ updateFieldValue, setFields }) {
     return <Loading />;
   }
 
+  function updateDateModified() {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${day}`;
+  }
+
   return data.fields.map((element, index) => {
     return (
       <div key={element._id} className="flex w-[500px]">
@@ -57,6 +66,16 @@ function AddDocInputList({ updateFieldValue, setFields }) {
               className="flex w-full h-7 rounded-md text-center"
               type={element.fieldType}
               onChange={event => updateFieldValue(index, event)}
+              defaultValue={
+                element.fieldType === "Date modified" ||
+                element.fieldType === "Date created"
+                  ? updateDateModified()
+                  : ""
+              }
+              disabled={
+                element.fieldType === "Date modified" ||
+                element.fieldType === "Date created"
+              }
             />
           )}
         </InputWrapper>

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -33,19 +33,19 @@ function AddDocumentModal({
   }
 
   function updateFieldValue(index, event) {
-    const newArr = [...fields];
+    const newFields = [...fields];
 
-    newArr[index].fieldValue = event.target.value;
+    newFields[index].fieldValue = event.target.value;
 
-    setFields(newArr);
+    setFields(newFields);
     adjustTextareaHeight(event);
   }
 
   function addNewDocumentId(newId) {
-    const newArr = [...documentsIds];
+    const newFields = [...documentsIds];
 
-    newArr.push(newId);
-    setDocumentsIds(newArr);
+    newFields.push(newId);
+    setDocumentsIds(newFields);
   }
 
   async function handleClickSave() {

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -43,21 +43,21 @@ function CreateDBModal({
   const [isFieldNameDuplicate, setIsFieldNameDuplicate] = useState(false);
 
   function updateFieldName(index, event) {
-    const newArr = [...fields];
-    newArr[index].fieldName = event.target.value;
+    const newFields = [...fields];
+    newFields[index].fieldName = event.target.value;
 
     setIsDBNameEmpty(false);
     setIsFieldNameEmpty(false);
     setIsFieldNameDuplicate(false);
 
-    setFields(newArr);
+    setFields(newFields);
   }
 
   function updateFieldType(index, event) {
-    const newArr = [...fields];
-    newArr[index].fieldType = event.target.value;
+    const newFields = [...fields];
+    newFields[index].fieldType = event.target.value;
 
-    setFields(newArr);
+    setFields(newFields);
   }
 
   function handleClickAddField() {
@@ -76,10 +76,10 @@ function CreateDBModal({
       return;
     }
 
-    const newArr = [...fields];
-    newArr.splice(index, 1);
+    const newFields = [...fields];
+    newFields.splice(index, 1);
 
-    setFields(newArr);
+    setFields(newFields);
   }
 
   async function fetchDatabase(newDatabase) {

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -12,6 +12,7 @@ import useLoading from "../../../utils/useLoading";
 import moveField from "../../../utils/moveField";
 import movePortal from "../../../utils/movePortal";
 import CONSTANT from "../../../constants/constant";
+import getTodaysDate from "../../../utils/getTodaysDate";
 
 function DetailView({
   isEditMode,
@@ -138,19 +139,13 @@ function DetailView({
   }
 
   function updateDateModified(newArr, fields) {
-    const today = new Date();
-    const year = today.getFullYear();
-    const month = String(today.getMonth() + 1).padStart(2, "0");
-    const day = String(today.getDate()).padStart(2, "0");
-    const todaysDate = `${year}/${month}/${day}`;
-
     const dateModifiedFieldIndex = fields.findIndex(
       field => field.fieldType === "Date modified",
     );
 
     if (dateModifiedFieldIndex !== -1) {
       newArr[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
-        todaysDate;
+        getTodaysDate();
     }
   }
 

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -11,8 +11,8 @@ import fetchData from "../../../utils/axios";
 import useLoading from "../../../utils/useLoading";
 import moveField from "../../../utils/moveField";
 import movePortal from "../../../utils/movePortal";
-import CONSTANT from "../../../constants/constant";
 import getTodaysDate from "../../../utils/getTodaysDate";
+import CONSTANT from "../../../constants/constant";
 
 function DetailView({
   isEditMode,
@@ -138,32 +138,32 @@ function DetailView({
     setIsOnSave(false);
   }
 
-  function updateDateModified(newArr, fields) {
+  function updateDateModified(newDocData, fields) {
     const dateModifiedFieldIndex = fields.findIndex(
       field => field.fieldType === "Date modified",
     );
 
     if (dateModifiedFieldIndex !== -1) {
-      newArr[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
+      newDocData[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
         getTodaysDate();
     }
   }
 
   function updateFieldValue(index, event) {
-    const newArr = [...docData];
+    const newDocData = [...docData];
 
-    newArr[currentDocIndex].fields[index].fieldValue = event.target.value;
+    newDocData[currentDocIndex].fields[index].fieldValue = event.target.value;
 
-    updateDateModified(newArr, newArr[currentDocIndex].fields);
-    setDocData(newArr);
+    updateDateModified(newDocData, newDocData[currentDocIndex].fields);
+    setDocData(newDocData);
   }
 
   function updateFieldRows(index, value) {
-    const newArr = [...docData];
+    const newDocData = [...docData];
 
-    newArr[currentDocIndex].fields[index].rows = value;
+    newDocData[currentDocIndex].fields[index].rows = value;
 
-    setDocData(newArr);
+    setDocData(newDocData);
   }
 
   function handleMouseUp() {

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -142,7 +142,7 @@ function DetailView({
     const year = today.getFullYear();
     const month = String(today.getMonth() + 1).padStart(2, "0");
     const day = String(today.getDate()).padStart(2, "0");
-    const todaysDate = `${year}-${month}-${day}`;
+    const todaysDate = `${year}/${month}/${day}`;
 
     const dateModifiedFieldIndex = fields.findIndex(
       field => field.fieldType === "Date modified",

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -137,11 +137,29 @@ function DetailView({
     setIsOnSave(false);
   }
 
+  function updateDateModified(newArr, fields) {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+    const todaysDate = `${year}-${month}-${day}`;
+
+    const dateModifiedFieldIndex = fields.findIndex(
+      field => field.fieldType === "Date modified",
+    );
+
+    if (dateModifiedFieldIndex !== -1) {
+      newArr[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
+        todaysDate;
+    }
+  }
+
   function updateFieldValue(index, event) {
     const newArr = [...docData];
 
     newArr[currentDocIndex].fields[index].fieldValue = event.target.value;
 
+    updateDateModified(newArr, newArr[currentDocIndex].fields);
     setDocData(newArr);
   }
 

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -25,7 +25,7 @@ function FieldList({
       >
         <div className="flex w-full h-full p-2">
           <span
-            className={`flex justify-end mr-3 w-[140px] select-none
+            className={`flex justify-end mr-3 w-[140px] select-none text-right
             ${isEditMode && "hover:cursor-move"}`}
             onMouseDown={event => {
               setDraggingElement(`field-${index}`);
@@ -66,7 +66,7 @@ function FieldList({
             </div>
           ) : (
             <input
-              className={`flex w-full mr-3 ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
+              className={`flex w-full ring-2 rounded-md ring-light-grey text-center focus:outline-none ${
                 isEditMode &&
                 !draggingElement &&
                 "hover:ring-2 hover:ring-blue hover:bg-blue hover:bg-opacity-20 focus:ring-2 focus:ring-blue focus:bg-blue focus:bg-opacity-20"

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -75,7 +75,11 @@ function FieldList({
               onDoubleClick={() => setIsEditMode(true)}
               onChange={event => updateFieldValue(index, event)}
               value={element.fieldValue}
-              readOnly={!isEditMode}
+              disabled={
+                element.fieldType === "Date modified" ||
+                element.fieldType === "Date created" ||
+                !isEditMode
+              }
             />
           )}
         </div>

--- a/src/components/contents/DetailViewItems/PortalFooter.jsx
+++ b/src/components/contents/DetailViewItems/PortalFooter.jsx
@@ -2,11 +2,11 @@ import Button from "../../shared/Button";
 
 function PortalFooter({ relationshipsData, setRelationshipsData, index }) {
   function handleClickSize(size) {
-    const newArr = [...relationshipsData];
+    const newRelationshipData = [...relationshipsData];
 
-    newArr[index].portalSize = size;
+    newRelationshipData[index].portalSize = size;
 
-    setRelationshipsData(newArr);
+    setRelationshipsData(newRelationshipData);
   }
 
   return (

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import getTodaysDate from "../../../utils/getTodaysDate";
 
 function TableBody({
   documents,
@@ -23,12 +24,6 @@ function TableBody({
   }, [documents]);
 
   function updateDateModified(newChangedDoc, documentIndex) {
-    const today = new Date();
-    const year = today.getFullYear();
-    const month = String(today.getMonth() + 1).padStart(2, "0");
-    const day = String(today.getDate()).padStart(2, "0");
-    const todaysDate = `${year}/${month}/${day}`;
-
     const dateModifiedFieldIndex = documents[documentIndex].fields.findIndex(
       field => field.fieldType === "Date modified",
     );
@@ -44,12 +39,12 @@ function TableBody({
       if (dateModifiedIndexInsideChangedDoc === -1) {
         newChangedDoc[documentIndex].fields.push({
           fieldId: dateModifiedFieldId,
-          fieldValue: todaysDate,
+          fieldValue: getTodaysDate(),
         });
       } else {
         newChangedDoc[documentIndex].fields[
           dateModifiedIndexInsideChangedDoc
-        ].fieldValue = todaysDate;
+        ].fieldValue = getTodaysDate();
       }
     }
   }

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -27,7 +27,7 @@ function TableBody({
     const year = today.getFullYear();
     const month = String(today.getMonth() + 1).padStart(2, "0");
     const day = String(today.getDate()).padStart(2, "0");
-    const todaysDate = `${year}-${month}-${day}`;
+    const todaysDate = `${year}/${month}/${day}`;
 
     const dateModifiedFieldIndex = documents[documentIndex].fields.findIndex(
       field => field.fieldType === "Date modified",

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -22,6 +22,38 @@ function TableBody({
     });
   }, [documents]);
 
+  function updateDateModified(newChangedDoc, documentIndex) {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+    const todaysDate = `${year}-${month}-${day}`;
+
+    const dateModifiedFieldIndex = documents[documentIndex].fields.findIndex(
+      field => field.fieldType === "Date modified",
+    );
+
+    if (dateModifiedFieldIndex !== -1) {
+      const dateModifiedFieldId =
+        documents[documentIndex].fields[dateModifiedFieldIndex]._id;
+
+      const dateModifiedIndexInsideChangedDoc = changedDoc[
+        documentIndex
+      ].fields.findIndex(field => field.fieldId === dateModifiedFieldId);
+
+      if (dateModifiedIndexInsideChangedDoc === -1) {
+        newChangedDoc[documentIndex].fields.push({
+          fieldId: dateModifiedFieldId,
+          fieldValue: todaysDate,
+        });
+      } else {
+        newChangedDoc[documentIndex].fields[
+          dateModifiedIndexInsideChangedDoc
+        ].fieldValue = todaysDate;
+      }
+    }
+  }
+
   function handleOnChange(event, documentId) {
     const { id, value } = event.target;
     const newChangedDoc = [...changedDoc];
@@ -43,6 +75,7 @@ function TableBody({
       newChangedDoc[documentIndex].fields[fieldIndex].fieldValue = value;
     }
 
+    updateDateModified(newChangedDoc, documentIndex);
     setChangedDoc(newChangedDoc);
     adjustTextareaHeight(event);
   }
@@ -92,7 +125,11 @@ function TableBody({
                     id={field._id}
                     type={field.fieldType}
                     defaultValue={field.fieldValue}
-                    disabled={!isEditMode}
+                    disabled={
+                      field.fieldType === "Date modified" ||
+                      field.fieldType === "Date created" ||
+                      !isEditMode
+                    }
                     onChange={event => handleOnChange(event, document._id)}
                   />
                 )}

--- a/src/utils/getTodaysDate.js
+++ b/src/utils/getTodaysDate.js
@@ -1,0 +1,10 @@
+function getTodaysDate() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+
+  return `${year}/${month}/${day}`;
+}
+
+export default getTodaysDate;

--- a/src/utils/moveField.js
+++ b/src/utils/moveField.js
@@ -20,7 +20,7 @@ function moveField(
   const elementWidth = 370;
   const elementHeight = elementScale[1] + 40;
 
-  const newArr = [...docData];
+  const newDocData = [...docData];
 
   const isAboveCanvas = currentYBasedOnCanvasArea < 0;
   const isLeftOfCanvas = currentXBasedOnCanvasArea < 0;
@@ -30,9 +30,9 @@ function moveField(
     currentYBasedOnCanvasArea > CONSTANT.CANVAS_H - elementHeight;
 
   function setCoordinates(x, y) {
-    newArr[currentDocIndex].fields[draggedElementIndex].xCoordinate = x;
-    newArr[currentDocIndex].fields[draggedElementIndex].yCoordinate = y;
-    setDocData(newArr);
+    newDocData[currentDocIndex].fields[draggedElementIndex].xCoordinate = x;
+    newDocData[currentDocIndex].fields[draggedElementIndex].yCoordinate = y;
+    setDocData(newDocData);
   }
 
   if (isAboveCanvas && isLeftOfCanvas) {

--- a/src/utils/movePortal.js
+++ b/src/utils/movePortal.js
@@ -19,7 +19,7 @@ function movePortal(
   const elementWidth = elementScale[0];
   const elementHeight = elementScale[1] + 10;
 
-  const newArr = [...relationshipsData];
+  const newRelationshipData = [...relationshipsData];
 
   const isAboveCanvas = currentYBasedOnCanvasArea < 0;
   const isLeftOfCanvas = currentXBasedOnCanvasArea < 0;
@@ -29,9 +29,9 @@ function movePortal(
     currentYBasedOnCanvasArea > CONSTANT.CANVAS_H - elementHeight;
 
   function setCoordinates(x, y) {
-    newArr[draggedPortalIndex].xCoordinate = x;
-    newArr[draggedPortalIndex].yCoordinate = y;
-    setRelationshipsData(newArr);
+    newRelationshipData[draggedPortalIndex].xCoordinate = x;
+    newRelationshipData[draggedPortalIndex].yCoordinate = y;
+    setRelationshipsData(newRelationshipData);
   }
 
   if (isAboveCanvas && isLeftOfCanvas) {


### PR DESCRIPTION
### description

list view, detail view, new document modal내부 코드를 변경하여 수정일 기능을 추가하였습니다.

- ListView의 경우 새 chanedDoc 장바구니에 바뀐것들만을 담아 fetch하는 스타일.
- DetailView의 경우, doc state를 복사해서 새버젼으로 갈아주고 현재 바라보는 도큐멘트 1개만 fetch하는 스타일.
이 다른점으로 인해 현재 각각 view에서의 Date modified을 갱신해주는 로직내용이 살짝 다릅니다.
그러나 해당 document의 수정일을 바꿔준다는 함수의 작동결과는 같습니다!

작성일 기능의 경우 프론트단에서는 일단 변경이 불가능하도록 블락하는 작업을 해주었습니다.
이어서 백엔드단에서 createAt과 modifiedAt(DB적용시점 날짜 우선)을 적용하는 작업을 하면 좋을 것 같습니다.
잘 부탁드립니다.

### conflict 발생 시

1. 충돌 해결은 반드시 에디터에서 할 것.
2. add
3. rebase —continue
4. push (origin feature)

### 주의 사항

- push는 반드시 해당 feature 브랜치에 할 것
- conflict를 모두 해결하고 PR 올리기
- PR시 conflict 발생 시와 주의 사항은 지우고 올려주세요

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.

### 스크린샷 (필요시)
![modi1](https://github.com/Team-Dataface/DataFace-client/assets/83858724/5598c443-b2b8-4543-835c-5e8e571f10a2)

![modi2](https://github.com/Team-Dataface/DataFace-client/assets/83858724/863499c7-79ed-42e9-8f45-212f54e796cf)

![modi3](https://github.com/Team-Dataface/DataFace-client/assets/83858724/d46ff609-00b5-46be-9f45-5e21ab02d400)
