### PR TITLE
Feat. change state management from prop drilling in to jotai library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^4.29.25",
         "axios": "^1.4.0",
         "firebase": "^10.0.0",
+        "jotai": "^2.5.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5624,13 +5625,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.15.tgz",
       "integrity": "sha512-oEjE7TQt1fFTFSbf8kkNuc798ahTUzn3Le67/PWjE8MAfYAD/qB7O8hSTcromLFqHCt9bcdOg5GXMokzTjJ5SA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5650,7 +5651,7 @@
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -7452,7 +7453,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -10953,6 +10954,26 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.5.1.tgz",
+      "integrity": "sha512-vanPCCSuHczUXNbVh/iUunuMfrWRL4FdBtAbTRmrfqezJcKb8ybBTg8iivyYuUHapjcDETyJe1E4inlo26bVHA==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^4.29.25",
     "axios": "^1.4.0",
     "firebase": "^10.0.0",
+    "jotai": "^2.5.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,9 +1,10 @@
 import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAtom } from "jotai";
 import { ErrorBoundary } from "react-error-boundary";
 
-import UserContext from "../context/UserContext";
+import { userAtom } from "../atoms/atoms";
+
 import authUser from "../utils/authUser";
 import Login from "../components/Login";
 import Header from "../components/Header";
@@ -19,7 +20,7 @@ import ErrorPage from "../components/shared/ErrorPage";
 import CONSTANT from "../constants/constant";
 
 function App() {
-  const [user, setUser] = useState("");
+  const [user, setUser] = useAtom(userAtom);
 
   const navigate = useNavigate();
 
@@ -49,26 +50,24 @@ function App() {
 
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>
-      <UserContext.Provider value={user}>
-        <div className="flex flex-col h-screen">
-          {user && <Header clickHandleLogout={setUser} />}
-          <div className="flex flex-1 overflow-y-auto">
-            {user && <Sidebar />}
-            <div className="flex grow justify-center">
-              <Routes>
-                <Route path="/login" element={<Login setUser={setUser} />} />
-                <Route path="/dashboard" element={<ContentsContainer />}>
-                  <Route path="listview" element={<ListView />} />
-                  <Route path="detailview" element={<DetailView />} />
-                  <Route path="relationship" element={<Relationship />} />
-                  <Route path="nodatabase" element={<NoDatabase />} />
-                </Route>
-                <Route path="/" element={<Navigate replace to="/login" />} />
-              </Routes>
-            </div>
+      <div className="flex flex-col h-screen">
+        {user && <Header />}
+        <div className="flex flex-1 overflow-y-auto">
+          {user && <Sidebar />}
+          <div className="flex grow justify-center">
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route path="/dashboard" element={<ContentsContainer />}>
+                <Route path="listview" element={<ListView />} />
+                <Route path="detailview" element={<DetailView />} />
+                <Route path="relationship" element={<Relationship />} />
+                <Route path="nodatabase" element={<NoDatabase />} />
+              </Route>
+              <Route path="/" element={<Navigate replace to="/login" />} />
+            </Routes>
           </div>
         </div>
-      </UserContext.Provider>
+      </div>
     </ErrorBoundary>
   );
 }

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,7 +21,6 @@ import CONSTANT from "../constants/constant";
 function App() {
   const [user, setUser] = useState("");
   const [documentsIds, setDocumentsIds] = useState([]);
-  const [isRelationship, setIsRelationship] = useState(false);
   const [isInitial, setIsInitial] = useState(true);
   const [relationshipsData, setRelationshipsData] = useState(null);
 
@@ -60,8 +59,6 @@ function App() {
               clickHandleLogout={setUser}
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
-              isRelationship={isRelationship}
-              setIsRelationship={setIsRelationship}
             />
           )}
           <div className="flex flex-1 overflow-y-auto">
@@ -69,7 +66,6 @@ function App() {
               <Sidebar
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
-                isRelationship={isRelationship}
                 setRelationshipsData={setRelationshipsData}
               />
             )}

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -20,7 +20,6 @@ import CONSTANT from "../constants/constant";
 
 function App() {
   const [user, setUser] = useState("");
-  const [isInitial, setIsInitial] = useState(true);
 
   const navigate = useNavigate();
 
@@ -54,9 +53,7 @@ function App() {
         <div className="flex flex-col h-screen">
           {user && <Header clickHandleLogout={setUser} />}
           <div className="flex flex-1 overflow-y-auto">
-            {user && (
-              <Sidebar isInitial={isInitial} setIsInitial={setIsInitial} />
-            )}
+            {user && <Sidebar />}
             <div className="flex grow justify-center">
               <Routes>
                 <Route path="/login" element={<Login setUser={setUser} />} />

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -20,7 +20,6 @@ import CONSTANT from "../constants/constant";
 
 function App() {
   const [user, setUser] = useState("");
-  const [currentDocIndex, setCurrentDocIndex] = useState(0);
   const [documentsIds, setDocumentsIds] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isOnSave, setIsOnSave] = useState(false);
@@ -63,8 +62,6 @@ function App() {
               clickHandleLogout={setUser}
               isEditMode={isEditMode}
               setIsEditMode={setIsEditMode}
-              currentDocIndex={currentDocIndex}
-              setCurrentDocIndex={setCurrentDocIndex}
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
               setIsOnSave={setIsOnSave}
@@ -78,9 +75,7 @@ function App() {
                 isEditMode={isEditMode}
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
-                setCurrentDocIndex={setCurrentDocIndex}
                 isRelationship={isRelationship}
-                currentDocIndex={currentDocIndex}
                 setRelationshipsData={setRelationshipsData}
               />
             )}
@@ -94,8 +89,6 @@ function App() {
                       <ListView
                         isEditMode={isEditMode}
                         setIsEditMode={setIsEditMode}
-                        currentDocIndex={currentDocIndex}
-                        setCurrentDocIndex={setCurrentDocIndex}
                         setDocumentsIds={setDocumentsIds}
                         isOnSave={isOnSave}
                         setIsOnSave={setIsOnSave}
@@ -108,8 +101,6 @@ function App() {
                       <DetailView
                         isEditMode={isEditMode}
                         setIsEditMode={setIsEditMode}
-                        currentDocIndex={currentDocIndex}
-                        setCurrentDocIndex={setCurrentDocIndex}
                         setDocumentsIds={setDocumentsIds}
                         isOnSave={isOnSave}
                         setIsOnSave={setIsOnSave}

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -22,7 +22,6 @@ function App() {
   const [user, setUser] = useState("");
   const [documentsIds, setDocumentsIds] = useState([]);
   const [isInitial, setIsInitial] = useState(true);
-  const [relationshipsData, setRelationshipsData] = useState(null);
 
   const navigate = useNavigate();
 
@@ -63,11 +62,7 @@ function App() {
           )}
           <div className="flex flex-1 overflow-y-auto">
             {user && (
-              <Sidebar
-                isInitial={isInitial}
-                setIsInitial={setIsInitial}
-                setRelationshipsData={setRelationshipsData}
-              />
+              <Sidebar isInitial={isInitial} setIsInitial={setIsInitial} />
             )}
             <div className="flex grow justify-center">
               <Routes>
@@ -79,13 +74,7 @@ function App() {
                   />
                   <Route
                     path="detailview"
-                    element={
-                      <DetailView
-                        setDocumentsIds={setDocumentsIds}
-                        relationshipsData={relationshipsData}
-                        setRelationshipsData={setRelationshipsData}
-                      />
-                    }
+                    element={<DetailView setDocumentsIds={setDocumentsIds} />}
                   />
                   <Route path="relationship" element={<Relationship />} />
                   <Route path="nodatabase" element={<NoDatabase />} />

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -20,7 +20,6 @@ import CONSTANT from "../constants/constant";
 
 function App() {
   const [user, setUser] = useState("");
-  const [documentsIds, setDocumentsIds] = useState([]);
   const [isInitial, setIsInitial] = useState(true);
 
   const navigate = useNavigate();
@@ -53,13 +52,7 @@ function App() {
     <ErrorBoundary FallbackComponent={ErrorPage}>
       <UserContext.Provider value={user}>
         <div className="flex flex-col h-screen">
-          {user && (
-            <Header
-              clickHandleLogout={setUser}
-              documentsIds={documentsIds}
-              setDocumentsIds={setDocumentsIds}
-            />
-          )}
+          {user && <Header clickHandleLogout={setUser} />}
           <div className="flex flex-1 overflow-y-auto">
             {user && (
               <Sidebar isInitial={isInitial} setIsInitial={setIsInitial} />
@@ -68,14 +61,8 @@ function App() {
               <Routes>
                 <Route path="/login" element={<Login setUser={setUser} />} />
                 <Route path="/dashboard" element={<ContentsContainer />}>
-                  <Route
-                    path="listview"
-                    element={<ListView setDocumentsIds={setDocumentsIds} />}
-                  />
-                  <Route
-                    path="detailview"
-                    element={<DetailView setDocumentsIds={setDocumentsIds} />}
-                  />
+                  <Route path="listview" element={<ListView />} />
+                  <Route path="detailview" element={<DetailView />} />
                   <Route path="relationship" element={<Relationship />} />
                   <Route path="nodatabase" element={<NoDatabase />} />
                 </Route>

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -26,7 +26,6 @@ function App() {
   const [isOnSave, setIsOnSave] = useState(false);
   const [isRelationship, setIsRelationship] = useState(false);
   const [isInitial, setIsInitial] = useState(true);
-  const [currentDBName, setCurrentDBName] = useState("");
   const [relationshipsData, setRelationshipsData] = useState(null);
 
   const navigate = useNavigate();
@@ -69,7 +68,6 @@ function App() {
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
               setIsOnSave={setIsOnSave}
-              currentDBName={currentDBName}
               isRelationship={isRelationship}
               setIsRelationship={setIsRelationship}
             />
@@ -81,7 +79,6 @@ function App() {
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
                 setCurrentDocIndex={setCurrentDocIndex}
-                setCurrentDBName={setCurrentDBName}
                 isRelationship={isRelationship}
                 currentDocIndex={currentDocIndex}
                 setRelationshipsData={setRelationshipsData}
@@ -122,10 +119,7 @@ function App() {
                     }
                   />
                   <Route path="relationship" element={<Relationship />} />
-                  <Route
-                    path="nodatabase"
-                    element={<NoDatabase setCurrentDBName={setCurrentDBName} />}
-                  />
+                  <Route path="nodatabase" element={<NoDatabase />} />
                 </Route>
                 <Route path="/" element={<Navigate replace to="/login" />} />
               </Routes>

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,7 +21,6 @@ import CONSTANT from "../constants/constant";
 function App() {
   const [user, setUser] = useState("");
   const [documentsIds, setDocumentsIds] = useState([]);
-  const [isOnSave, setIsOnSave] = useState(false);
   const [isRelationship, setIsRelationship] = useState(false);
   const [isInitial, setIsInitial] = useState(true);
   const [relationshipsData, setRelationshipsData] = useState(null);
@@ -61,7 +60,6 @@ function App() {
               clickHandleLogout={setUser}
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
-              setIsOnSave={setIsOnSave}
               isRelationship={isRelationship}
               setIsRelationship={setIsRelationship}
             />
@@ -81,21 +79,13 @@ function App() {
                 <Route path="/dashboard" element={<ContentsContainer />}>
                   <Route
                     path="listview"
-                    element={
-                      <ListView
-                        setDocumentsIds={setDocumentsIds}
-                        isOnSave={isOnSave}
-                        setIsOnSave={setIsOnSave}
-                      />
-                    }
+                    element={<ListView setDocumentsIds={setDocumentsIds} />}
                   />
                   <Route
                     path="detailview"
                     element={
                       <DetailView
                         setDocumentsIds={setDocumentsIds}
-                        isOnSave={isOnSave}
-                        setIsOnSave={setIsOnSave}
                         relationshipsData={relationshipsData}
                         setRelationshipsData={setRelationshipsData}
                       />

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,7 +21,6 @@ import CONSTANT from "../constants/constant";
 function App() {
   const [user, setUser] = useState("");
   const [documentsIds, setDocumentsIds] = useState([]);
-  const [isEditMode, setIsEditMode] = useState(false);
   const [isOnSave, setIsOnSave] = useState(false);
   const [isRelationship, setIsRelationship] = useState(false);
   const [isInitial, setIsInitial] = useState(true);
@@ -60,8 +59,6 @@ function App() {
           {user && (
             <Header
               clickHandleLogout={setUser}
-              isEditMode={isEditMode}
-              setIsEditMode={setIsEditMode}
               documentsIds={documentsIds}
               setDocumentsIds={setDocumentsIds}
               setIsOnSave={setIsOnSave}
@@ -72,7 +69,6 @@ function App() {
           <div className="flex flex-1 overflow-y-auto">
             {user && (
               <Sidebar
-                isEditMode={isEditMode}
                 isInitial={isInitial}
                 setIsInitial={setIsInitial}
                 isRelationship={isRelationship}
@@ -87,8 +83,6 @@ function App() {
                     path="listview"
                     element={
                       <ListView
-                        isEditMode={isEditMode}
-                        setIsEditMode={setIsEditMode}
                         setDocumentsIds={setDocumentsIds}
                         isOnSave={isOnSave}
                         setIsOnSave={setIsOnSave}
@@ -99,8 +93,6 @@ function App() {
                     path="detailview"
                     element={
                       <DetailView
-                        isEditMode={isEditMode}
-                        setIsEditMode={setIsEditMode}
                         setDocumentsIds={setDocumentsIds}
                         isOnSave={isOnSave}
                         setIsOnSave={setIsOnSave}

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -4,7 +4,6 @@ import { useQuery } from "@tanstack/react-query";
 import { ErrorBoundary } from "react-error-boundary";
 
 import UserContext from "../context/UserContext";
-import CurrentDBIdContext from "../context/CurrentDBIdContext";
 import authUser from "../utils/authUser";
 import Login from "../components/Login";
 import Header from "../components/Header";
@@ -21,7 +20,6 @@ import CONSTANT from "../constants/constant";
 
 function App() {
   const [user, setUser] = useState("");
-  const [currentDBId, setCurrentDBId] = useState("");
   const [currentDocIndex, setCurrentDocIndex] = useState(0);
   const [documentsIds, setDocumentsIds] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -60,88 +58,80 @@ function App() {
   return (
     <ErrorBoundary FallbackComponent={ErrorPage}>
       <UserContext.Provider value={user}>
-        <CurrentDBIdContext.Provider value={currentDBId}>
-          <div className="flex flex-col h-screen">
+        <div className="flex flex-col h-screen">
+          {user && (
+            <Header
+              clickHandleLogout={setUser}
+              isEditMode={isEditMode}
+              setIsEditMode={setIsEditMode}
+              currentDocIndex={currentDocIndex}
+              setCurrentDocIndex={setCurrentDocIndex}
+              documentsIds={documentsIds}
+              setDocumentsIds={setDocumentsIds}
+              setIsOnSave={setIsOnSave}
+              currentDBName={currentDBName}
+              isRelationship={isRelationship}
+              setIsRelationship={setIsRelationship}
+            />
+          )}
+          <div className="flex flex-1 overflow-y-auto">
             {user && (
-              <Header
-                clickHandleLogout={setUser}
+              <Sidebar
                 isEditMode={isEditMode}
-                setIsEditMode={setIsEditMode}
-                currentDocIndex={currentDocIndex}
+                isInitial={isInitial}
+                setIsInitial={setIsInitial}
                 setCurrentDocIndex={setCurrentDocIndex}
-                documentsIds={documentsIds}
-                setDocumentsIds={setDocumentsIds}
-                setIsOnSave={setIsOnSave}
-                currentDBName={currentDBName}
+                setCurrentDBName={setCurrentDBName}
                 isRelationship={isRelationship}
-                setIsRelationship={setIsRelationship}
+                currentDocIndex={currentDocIndex}
+                setRelationshipsData={setRelationshipsData}
               />
             )}
-            <div className="flex flex-1 overflow-y-auto">
-              {user && (
-                <Sidebar
-                  isEditMode={isEditMode}
-                  setCurrentDBId={setCurrentDBId}
-                  isInitial={isInitial}
-                  setIsInitial={setIsInitial}
-                  setCurrentDocIndex={setCurrentDocIndex}
-                  setCurrentDBName={setCurrentDBName}
-                  isRelationship={isRelationship}
-                  currentDocIndex={currentDocIndex}
-                  setRelationshipsData={setRelationshipsData}
-                />
-              )}
-              <div className="flex grow justify-center">
-                <Routes>
-                  <Route path="/login" element={<Login setUser={setUser} />} />
-                  <Route path="/dashboard" element={<ContentsContainer />}>
-                    <Route
-                      path="listview"
-                      element={
-                        <ListView
-                          isEditMode={isEditMode}
-                          setIsEditMode={setIsEditMode}
-                          currentDocIndex={currentDocIndex}
-                          setCurrentDocIndex={setCurrentDocIndex}
-                          setDocumentsIds={setDocumentsIds}
-                          isOnSave={isOnSave}
-                          setIsOnSave={setIsOnSave}
-                        />
-                      }
-                    />
-                    <Route
-                      path="detailview"
-                      element={
-                        <DetailView
-                          isEditMode={isEditMode}
-                          setIsEditMode={setIsEditMode}
-                          currentDocIndex={currentDocIndex}
-                          setCurrentDocIndex={setCurrentDocIndex}
-                          setDocumentsIds={setDocumentsIds}
-                          isOnSave={isOnSave}
-                          setIsOnSave={setIsOnSave}
-                          relationshipsData={relationshipsData}
-                          setRelationshipsData={setRelationshipsData}
-                        />
-                      }
-                    />
-                    <Route path="relationship" element={<Relationship />} />
-                    <Route
-                      path="nodatabase"
-                      element={
-                        <NoDatabase
-                          setCurrentDBId={setCurrentDBId}
-                          setCurrentDBName={setCurrentDBName}
-                        />
-                      }
-                    />
-                  </Route>
-                  <Route path="/" element={<Navigate replace to="/login" />} />
-                </Routes>
-              </div>
+            <div className="flex grow justify-center">
+              <Routes>
+                <Route path="/login" element={<Login setUser={setUser} />} />
+                <Route path="/dashboard" element={<ContentsContainer />}>
+                  <Route
+                    path="listview"
+                    element={
+                      <ListView
+                        isEditMode={isEditMode}
+                        setIsEditMode={setIsEditMode}
+                        currentDocIndex={currentDocIndex}
+                        setCurrentDocIndex={setCurrentDocIndex}
+                        setDocumentsIds={setDocumentsIds}
+                        isOnSave={isOnSave}
+                        setIsOnSave={setIsOnSave}
+                      />
+                    }
+                  />
+                  <Route
+                    path="detailview"
+                    element={
+                      <DetailView
+                        isEditMode={isEditMode}
+                        setIsEditMode={setIsEditMode}
+                        currentDocIndex={currentDocIndex}
+                        setCurrentDocIndex={setCurrentDocIndex}
+                        setDocumentsIds={setDocumentsIds}
+                        isOnSave={isOnSave}
+                        setIsOnSave={setIsOnSave}
+                        relationshipsData={relationshipsData}
+                        setRelationshipsData={setRelationshipsData}
+                      />
+                    }
+                  />
+                  <Route path="relationship" element={<Relationship />} />
+                  <Route
+                    path="nodatabase"
+                    element={<NoDatabase setCurrentDBName={setCurrentDBName} />}
+                  />
+                </Route>
+                <Route path="/" element={<Navigate replace to="/login" />} />
+              </Routes>
             </div>
           </div>
-        </CurrentDBIdContext.Provider>
+        </div>
       </UserContext.Provider>
     </ErrorBoundary>
   );

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -21,7 +21,6 @@ import CONSTANT from "../constants/constant";
 
 function App() {
   const [user, setUser] = useState("");
-  const [isListView, setIsListView] = useState(true);
   const [currentDBId, setCurrentDBId] = useState("");
   const [currentDocIndex, setCurrentDocIndex] = useState(0);
   const [documentsIds, setDocumentsIds] = useState([]);
@@ -76,8 +75,6 @@ function App() {
                 currentDBName={currentDBName}
                 isRelationship={isRelationship}
                 setIsRelationship={setIsRelationship}
-                isListView={isListView}
-                setIsListView={setIsListView}
               />
             )}
             <div className="flex flex-1 overflow-y-auto">
@@ -90,7 +87,6 @@ function App() {
                   setCurrentDocIndex={setCurrentDocIndex}
                   setCurrentDBName={setCurrentDBName}
                   isRelationship={isRelationship}
-                  setIsListView={setIsListView}
                   currentDocIndex={currentDocIndex}
                   setRelationshipsData={setRelationshipsData}
                 />
@@ -136,8 +132,6 @@ function App() {
                         <NoDatabase
                           setCurrentDBId={setCurrentDBId}
                           setCurrentDBName={setCurrentDBName}
-                          isListView={isListView}
-                          setIsListView={setIsListView}
                         />
                       }
                     />

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -1,0 +1,5 @@
+import { atom } from "jotai";
+
+const isListViewAtom = atom(true);
+
+export default isListViewAtom;

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -1,5 +1,7 @@
 import { atom } from "jotai";
 
+export const userAtom = atom("");
+
 export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -22,3 +22,6 @@ export const draggingElementAtom = atom(null);
 export const elementScaleAtom = atom([]);
 
 export const showCreateDBModalAtom = atom(false);
+export const showAddDocumentModalAtom = atom(false);
+export const showDeleteDocumentModalAtom = atom(false);
+export const isLastDocumentAtom = atom(false);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -7,3 +7,4 @@ export const currentDocIndexAtom = atom(0);
 export const isEditModeAtom = atom(false);
 export const isOnSaveAtom = atom(false);
 export const isRelationshipAtom = atom(false);
+export const relationshipsDataAtom = atom(null);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -2,3 +2,4 @@ import { atom } from "jotai";
 
 export const isListViewAtom = atom(true);
 export const currentDBIdAtom = atom("");
+export const currentDBNameAtom = atom("");

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -20,3 +20,5 @@ export const docDataAtom = atom([]);
 export const primaryFieldAtom = atom(null);
 export const draggingElementAtom = atom(null);
 export const elementScaleAtom = atom([]);
+
+export const showCreateDBModalAtom = atom(false);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -6,3 +6,4 @@ export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);
 export const isEditModeAtom = atom(false);
 export const isOnSaveAtom = atom(false);
+export const isRelationshipAtom = atom(false);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -5,3 +5,4 @@ export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);
 export const isEditModeAtom = atom(false);
+export const isOnSaveAtom = atom(false);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -4,3 +4,4 @@ export const isListViewAtom = atom(true);
 export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);
+export const isEditModeAtom = atom(false);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -1,10 +1,14 @@
 import { atom } from "jotai";
 
-export const isListViewAtom = atom(true);
 export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);
+
 export const isEditModeAtom = atom(false);
-export const isOnSaveAtom = atom(false);
+export const isListViewAtom = atom(true);
 export const isRelationshipAtom = atom(false);
+
+export const isOnSaveAtom = atom(false);
+
 export const relationshipsDataAtom = atom(null);
+export const documentsIdsAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -12,3 +12,5 @@ export const isOnSaveAtom = atom(false);
 
 export const relationshipsDataAtom = atom(null);
 export const documentsIdsAtom = atom([]);
+
+export const isInitialAtom = atom(true);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -25,3 +25,5 @@ export const showCreateDBModalAtom = atom(false);
 export const showAddDocumentModalAtom = atom(false);
 export const showDeleteDocumentModalAtom = atom(false);
 export const isLastDocumentAtom = atom(false);
+
+export const fieldsAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -24,6 +24,7 @@ export const elementScaleAtom = atom([]);
 export const showCreateDBModalAtom = atom(false);
 export const showAddDocumentModalAtom = atom(false);
 export const showDeleteDocumentModalAtom = atom(false);
+export const showRelationshipModalAtom = atom(false);
 export const isLastDocumentAtom = atom(false);
 
 export const fieldsAtom = atom([]);
@@ -34,3 +35,14 @@ export const dbFieldsAtom = atom([
     fieldType: "Text",
   },
 ]);
+
+export const relationshipsAtom = atom([]);
+export const relationshipStepAtom = atom("start");
+export const relationDataAtom = atom({
+  primaryFieldName: "",
+  foreignDbId: "",
+  foreignFieldName: "",
+  foreignFieldsToDisplay: [],
+  foreignDb: null,
+});
+export const targetDatabasesAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -27,3 +27,10 @@ export const showDeleteDocumentModalAtom = atom(false);
 export const isLastDocumentAtom = atom(false);
 
 export const fieldsAtom = atom([]);
+export const dbFieldsAtom = atom([
+  {
+    id: crypto.randomUUID(),
+    fieldName: "",
+    fieldType: "Text",
+  },
+]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -3,3 +3,4 @@ import { atom } from "jotai";
 export const isListViewAtom = atom(true);
 export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
+export const currentDocIndexAtom = atom(0);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
 
-const isListViewAtom = atom(true);
-
-export default isListViewAtom;
+export const isListViewAtom = atom(true);
+export const currentDBIdAtom = atom("");

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -10,10 +10,13 @@ export const isEditModeAtom = atom(false);
 export const isListViewAtom = atom(true);
 export const isRelationshipAtom = atom(false);
 
-export const isOnSaveAtom = atom(false);
-
 export const relationshipsDataAtom = atom(null);
 export const documentsIdsAtom = atom([]);
 
 export const isInitialAtom = atom(true);
 export const changedDocAtom = atom([]);
+
+export const docDataAtom = atom([]);
+export const primaryFieldAtom = atom(null);
+export const draggingElementAtom = atom(null);
+export const elementScaleAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -16,3 +16,4 @@ export const relationshipsDataAtom = atom(null);
 export const documentsIdsAtom = atom([]);
 
 export const isInitialAtom = atom(true);
+export const changedDocAtom = atom([]);

--- a/src/components/ContentsContainer.jsx
+++ b/src/components/ContentsContainer.jsx
@@ -1,15 +1,15 @@
-import { useContext } from "react";
+import { useAtomValue } from "jotai";
 import { Outlet, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import fetchData from "../utils/axios";
+import { userAtom } from "../atoms/atoms";
 
-import UserContext from "../context/UserContext";
 import Loading from "./shared/Loading";
 
 function ContentsContainer() {
   const navigate = useNavigate();
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);

--- a/src/components/ContentsContainer.jsx
+++ b/src/components/ContentsContainer.jsx
@@ -14,7 +14,7 @@ function ContentsContainer() {
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);
 
-    return response;
+    return response.data.databases;
   }
 
   const { isLoading } = useQuery(["userDbList"], getDatabaseList, {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,7 +7,7 @@ import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({ clickHandleLogout, documentsIds, setDocumentsIds }) {
+function Header({ clickHandleLogout }) {
   const currentDBName = useAtomValue(currentDBNameAtom);
 
   return (
@@ -23,12 +23,7 @@ function Header({ clickHandleLogout, documentsIds, setDocumentsIds }) {
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
-        {currentDBName && (
-          <Toolbar
-            documentsIds={documentsIds}
-            setDocumentsIds={setDocumentsIds}
-          />
-        )}
+        {currentDBName && <Toolbar />}
         {currentDBName && <SaveButton />}
       </div>
     </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,7 +11,6 @@ function Header({
   clickHandleLogout,
   documentsIds,
   setDocumentsIds,
-  setIsOnSave,
   isRelationship,
   setIsRelationship,
 }) {
@@ -38,12 +37,7 @@ function Header({
             setIsRelationship={setIsRelationship}
           />
         )}
-        {currentDBName && (
-          <SaveButton
-            setIsOnSave={setIsOnSave}
-            isRelationship={isRelationship}
-          />
-        )}
+        {currentDBName && <SaveButton isRelationship={isRelationship} />}
       </div>
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,4 @@
 import { useAtomValue } from "jotai";
-import PropTypes from "prop-types";
 
 import { currentDBNameAtom } from "../atoms/atoms";
 
@@ -7,7 +6,7 @@ import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({ clickHandleLogout }) {
+function Header() {
   const currentDBName = useAtomValue(currentDBNameAtom);
 
   return (
@@ -19,7 +18,7 @@ function Header({ clickHandleLogout }) {
           alt="dataface logo"
         />
         <span className="text-white">{currentDBName}</span>
-        <LogoutButton clickHandleLogout={clickHandleLogout} />
+        <LogoutButton />
       </div>
 
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
@@ -29,9 +28,5 @@ function Header({ clickHandleLogout }) {
     </div>
   );
 }
-
-Header.propTypes = {
-  clickHandleLogout: PropTypes.func.isRequired,
-};
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,8 +11,6 @@ function Header({
   clickHandleLogout,
   isEditMode,
   setIsEditMode,
-  currentDocIndex,
-  setCurrentDocIndex,
   documentsIds,
   setDocumentsIds,
   setIsOnSave,
@@ -37,8 +35,6 @@ function Header({
         {currentDBName && (
           <Toolbar
             isEditMode={isEditMode}
-            currentDocIndex={currentDocIndex}
-            setCurrentDocIndex={setCurrentDocIndex}
             documentsIds={documentsIds}
             setDocumentsIds={setDocumentsIds}
             isRelationship={isRelationship}
@@ -62,8 +58,6 @@ Header.propTypes = {
   clickHandleLogout: PropTypes.func.isRequired,
   isEditMode: PropTypes.bool.isRequired,
   setIsEditMode: PropTypes.func.isRequired,
-  currentDocIndex: PropTypes.number.isRequired,
-  setCurrentDocIndex: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -5,8 +5,6 @@ import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
 function Header({
-  isListView,
-  setIsListView,
   clickHandleLogout,
   isEditMode,
   setIsEditMode,
@@ -41,8 +39,6 @@ function Header({
             setDocumentsIds={setDocumentsIds}
             isRelationship={isRelationship}
             setIsRelationship={setIsRelationship}
-            isListView={isListView}
-            setIsListView={setIsListView}
           />
         )}
         {currentDBName && (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,8 +9,6 @@ import SaveButton from "./HeaderItems/SaveButton";
 
 function Header({
   clickHandleLogout,
-  isEditMode,
-  setIsEditMode,
   documentsIds,
   setDocumentsIds,
   setIsOnSave,
@@ -34,7 +32,6 @@ function Header({
       <div className="flex flex-row justify-between items-center h-[70px] p-3 bg-black-bg">
         {currentDBName && (
           <Toolbar
-            isEditMode={isEditMode}
             documentsIds={documentsIds}
             setDocumentsIds={setDocumentsIds}
             isRelationship={isRelationship}
@@ -43,8 +40,6 @@ function Header({
         )}
         {currentDBName && (
           <SaveButton
-            isEditMode={isEditMode}
-            setIsEditMode={setIsEditMode}
             setIsOnSave={setIsOnSave}
             isRelationship={isRelationship}
           />
@@ -56,8 +51,6 @@ function Header({
 
 Header.propTypes = {
   clickHandleLogout: PropTypes.func.isRequired,
-  isEditMode: PropTypes.bool.isRequired,
-  setIsEditMode: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,13 +7,7 @@ import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
 import SaveButton from "./HeaderItems/SaveButton";
 
-function Header({
-  clickHandleLogout,
-  documentsIds,
-  setDocumentsIds,
-  isRelationship,
-  setIsRelationship,
-}) {
+function Header({ clickHandleLogout, documentsIds, setDocumentsIds }) {
   const currentDBName = useAtomValue(currentDBNameAtom);
 
   return (
@@ -33,11 +27,9 @@ function Header({
           <Toolbar
             documentsIds={documentsIds}
             setDocumentsIds={setDocumentsIds}
-            isRelationship={isRelationship}
-            setIsRelationship={setIsRelationship}
           />
         )}
-        {currentDBName && <SaveButton isRelationship={isRelationship} />}
+        {currentDBName && <SaveButton />}
       </div>
     </div>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,7 @@
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
+
+import { currentDBNameAtom } from "../atoms/atoms";
 
 import LogoutButton from "./HeaderItems/LogoutButton";
 import Toolbar from "./HeaderItems/Toolbar";
@@ -13,10 +16,11 @@ function Header({
   documentsIds,
   setDocumentsIds,
   setIsOnSave,
-  currentDBName,
   isRelationship,
   setIsRelationship,
 }) {
+  const currentDBName = useAtomValue(currentDBNameAtom);
+
   return (
     <div className="flex flex-col w-full h-min-[120px] bg-black-bg">
       <div className="flex flex-row justify-between items-center h-[50px] p-3 bg-black-bg">

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -4,18 +4,23 @@ import { useAtom, useAtomValue } from "jotai";
 
 import fetchData from "../../utils/axios";
 
-import { currentDBIdAtom, currentDocIndexAtom } from "../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDocIndexAtom,
+  isEditModeAtom,
+} from "../../atoms/atoms";
 import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
 import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 import Loading from "../shared/Loading";
 
-function DocHandlerButtons({ isEditMode, documentsIds, setDocumentsIds }) {
+function DocHandlerButtons({ documentsIds, setDocumentsIds }) {
   const { userId } = useContext(UserContext);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
   const [showDeleteDocumentModal, setShowDeleteDocumentModal] = useState(false);

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,11 +1,12 @@
 import { useState, useContext } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../utils/axios";
 
+import { currentDBIdAtom } from "../../atoms/atoms";
 import UserContext from "../../context/UserContext";
-import CurrentDBIdContext from "../../context/CurrentDBIdContext";
 import Button from "../shared/Button";
 import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
@@ -19,7 +20,7 @@ function DocHandlerButtons({
   setDocumentsIds,
 }) {
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
   const [showDeleteDocumentModal, setShowDeleteDocumentModal] = useState(false);

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useAtomValue } from "jotai";
 
@@ -9,15 +9,16 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   documentsIdsAtom,
+  userAtom,
 } from "../../atoms/atoms";
-import UserContext from "../../context/UserContext";
+
 import Button from "../shared/Button";
 import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 import Loading from "../shared/Loading";
 
 function DocHandlerButtons() {
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -8,6 +8,7 @@ import {
   currentDBIdAtom,
   currentDocIndexAtom,
   isEditModeAtom,
+  documentsIdsAtom,
 } from "../../atoms/atoms";
 import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
@@ -15,12 +16,13 @@ import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 import Loading from "../shared/Loading";
 
-function DocHandlerButtons({ documentsIds, setDocumentsIds }) {
+function DocHandlerButtons() {
   const { userId } = useContext(UserContext);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
+  const documentsIds = useAtomValue(documentsIdsAtom);
 
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
   const [showDeleteDocumentModal, setShowDeleteDocumentModal] = useState(false);
@@ -136,17 +138,11 @@ function DocHandlerButtons({ documentsIds, setDocumentsIds }) {
         <img src="/assets/minus_icon.svg" alt="minus icon" />
       </Button>
       {showAddDocumentModal && (
-        <AddDocModal
-          closeModal={() => setShowAddDocumentModal(false)}
-          documentsIds={documentsIds}
-          setDocumentsIds={setDocumentsIds}
-        />
+        <AddDocModal closeModal={() => setShowAddDocumentModal(false)} />
       )}
       {showDeleteDocumentModal && (
         <DeleteDocModal
-          user={userId}
           closeModal={() => setShowDeleteDocumentModal(false)}
-          documentsIds={documentsIds}
           isLastDocument={isLastDocument}
           setIsLastDocument={setIsLastDocument}
         />

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,25 +1,20 @@
 import { useState, useContext } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
-import PropTypes from "prop-types";
+import { useAtom, useAtomValue } from "jotai";
 
 import fetchData from "../../utils/axios";
 
-import { currentDBIdAtom } from "../../atoms/atoms";
+import { currentDBIdAtom, currentDocIndexAtom } from "../../atoms/atoms";
 import UserContext from "../../context/UserContext";
 import Button from "../shared/Button";
 import AddDocModal from "../Modals/AddNewDocument/AddDocModal";
 import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 import Loading from "../shared/Loading";
 
-function DocHandlerButtons({
-  isEditMode,
-  currentDocIndex,
-  setCurrentDocIndex,
-  documentsIds,
-  setDocumentsIds,
-}) {
+function DocHandlerButtons({ isEditMode, documentsIds, setDocumentsIds }) {
   const { userId } = useContext(UserContext);
+
+  const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
@@ -140,17 +135,13 @@ function DocHandlerButtons({
           closeModal={() => setShowAddDocumentModal(false)}
           documentsIds={documentsIds}
           setDocumentsIds={setDocumentsIds}
-          currentDocIndex={currentDocIndex}
-          setCurrentDocIndex={setCurrentDocIndex}
         />
       )}
       {showDeleteDocumentModal && (
         <DeleteDocModal
           user={userId}
           closeModal={() => setShowDeleteDocumentModal(false)}
-          currentDocIndex={currentDocIndex}
           documentsIds={documentsIds}
-          setCurrentDocIndex={setCurrentDocIndex}
           isLastDocument={isLastDocument}
           setIsLastDocument={setIsLastDocument}
         />
@@ -158,10 +149,5 @@ function DocHandlerButtons({
     </div>
   );
 }
-
-DocHandlerButtons.propTypes = {
-  currentDocIndex: PropTypes.number.isRequired,
-  setCurrentDocIndex: PropTypes.func.isRequired,
-};
 
 export default DocHandlerButtons;

--- a/src/components/HeaderItems/DocHandlerButtons.jsx
+++ b/src/components/HeaderItems/DocHandlerButtons.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import fetchData from "../../utils/axios";
 
@@ -10,6 +10,9 @@ import {
   isEditModeAtom,
   documentsIdsAtom,
   userAtom,
+  showAddDocumentModalAtom,
+  showDeleteDocumentModalAtom,
+  isLastDocumentAtom,
 } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
@@ -18,19 +21,23 @@ import DeleteDocModal from "../Modals/DeleteDocument/DeleteDocModal";
 import Loading from "../shared/Loading";
 
 function DocHandlerButtons() {
-  const { userId } = useAtomValue(userAtom);
+  const [documentsNum, setDocumentsNum] = useState(0);
+  const queryClient = useQueryClient();
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
+  const [showAddDocumentModal, setShowAddDocumentModal] = useAtom(
+    showAddDocumentModalAtom,
+  );
+  const [showDeleteDocumentModal, setShowDeleteDocumentModal] = useAtom(
+    showDeleteDocumentModalAtom,
+  );
+
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
   const documentsIds = useAtomValue(documentsIdsAtom);
 
-  const [showAddDocumentModal, setShowAddDocumentModal] = useState(false);
-  const [showDeleteDocumentModal, setShowDeleteDocumentModal] = useState(false);
-  const [documentsNum, setDocumentsNum] = useState(0);
-  const [isLastDocument, setIsLastDocument] = useState(false);
-
-  const queryClient = useQueryClient();
+  const setIsLastDocument = useSetAtom(isLastDocumentAtom);
 
   const currentDocIndexShownToUser = currentDocIndex + 1;
 
@@ -138,16 +145,8 @@ function DocHandlerButtons() {
       >
         <img src="/assets/minus_icon.svg" alt="minus icon" />
       </Button>
-      {showAddDocumentModal && (
-        <AddDocModal closeModal={() => setShowAddDocumentModal(false)} />
-      )}
-      {showDeleteDocumentModal && (
-        <DeleteDocModal
-          closeModal={() => setShowDeleteDocumentModal(false)}
-          isLastDocument={isLastDocument}
-          setIsLastDocument={setIsLastDocument}
-        />
-      )}
+      {showAddDocumentModal && <AddDocModal />}
+      {showDeleteDocumentModal && <DeleteDocModal />}
     </div>
   );
 }

--- a/src/components/HeaderItems/LogoutButton.jsx
+++ b/src/components/HeaderItems/LogoutButton.jsx
@@ -1,16 +1,19 @@
-import PropTypes from "prop-types";
-
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSetAtom } from "jotai";
 
 import fetchData from "../../utils/axios";
+
+import { userAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 import Loading from "../shared/Loading";
 
-function LogoutButton({ clickHandleLogout }) {
+function LogoutButton() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const setUser = useSetAtom(userAtom);
 
   async function handleGoogleLogout() {
     await fetchData("POST", "/auth/logout");
@@ -18,7 +21,7 @@ function LogoutButton({ clickHandleLogout }) {
 
   const { mutate: fetchLogout, isLoading } = useMutation(handleGoogleLogout, {
     onSuccess: () => {
-      clickHandleLogout("");
+      setUser("");
       queryClient.clear();
       navigate("/login");
     },
@@ -42,9 +45,5 @@ function LogoutButton({ clickHandleLogout }) {
     </div>
   );
 }
-
-LogoutButton.propTypes = {
-  clickHandleLogout: PropTypes.func.isRequired,
-};
 
 export default LogoutButton;

--- a/src/components/HeaderItems/RelationshipButton.jsx
+++ b/src/components/HeaderItems/RelationshipButton.jsx
@@ -1,9 +1,12 @@
+import { useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 
+import { isEditModeAtom } from "../../atoms/atoms";
 import Button from "../shared/Button";
 
-function RelationshipButton({ isEditMode, isRelationship, setIsRelationship }) {
+function RelationshipButton({ isRelationship, setIsRelationship }) {
   const navigate = useNavigate();
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   function clickHandleRelationship() {
     setIsRelationship(true);

--- a/src/components/HeaderItems/RelationshipButton.jsx
+++ b/src/components/HeaderItems/RelationshipButton.jsx
@@ -1,11 +1,12 @@
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 
-import { isEditModeAtom } from "../../atoms/atoms";
+import { isEditModeAtom, isRelationshipAtom } from "../../atoms/atoms";
 import Button from "../shared/Button";
 
-function RelationshipButton({ isRelationship, setIsRelationship }) {
+function RelationshipButton() {
   const navigate = useNavigate();
+  const [isRelationship, setIsRelationship] = useAtom(isRelationshipAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
   function clickHandleRelationship() {

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,13 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useSetAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
 import {
   isEditModeAtom,
-  isOnSaveAtom,
   isRelationshipAtom,
   userAtom,
   currentDBIdAtom,
   changedDocAtom,
+  isListViewAtom,
+  docDataAtom,
+  currentDocIndexAtom,
+  relationshipsDataAtom,
 } from "../../atoms/atoms";
 
 import fetchData from "../../utils/axios";
@@ -18,19 +21,40 @@ function SaveButton() {
   const queryClient = useQueryClient();
 
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
-  const setIsOnSave = useSetAtom(isOnSaveAtom);
 
   const isRelationship = useAtomValue(isRelationshipAtom);
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const changedDoc = useAtomValue(changedDocAtom);
+  const isListview = useAtomValue(isListViewAtom);
+  const docData = useAtomValue(docDataAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   async function handleClickSave() {
+    if (isListview) {
+      await fetchData(
+        "PUT",
+        `/users/${userId}/databases/${currentDBId}/documents`,
+        changedDoc,
+      );
+
+      return;
+    }
+
     await fetchData(
       "PUT",
-      `/users/${userId}/databases/${currentDBId}/documents`,
-      changedDoc,
+      `/users/${userId}/databases/${currentDBId}/documents/${docData[currentDocIndex]._id}`,
+      { fields: docData[currentDocIndex].fields },
     );
+
+    if (relationshipsData?.length) {
+      await fetchData(
+        "PUT",
+        `/users/${userId}/databases/${currentDBId}/relationships`,
+        relationshipsData,
+      );
+    }
   }
 
   const { mutate: fetchDocumentUpdate } = useMutation(handleClickSave, {
@@ -54,7 +78,6 @@ function SaveButton() {
         onClick={() => {
           if (isEditMode) {
             fetchDocumentUpdate();
-            setIsOnSave(false);
           }
           setIsEditMode(!isEditMode);
         }}

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,13 +1,12 @@
-import PropTypes from "prop-types";
+import { useAtom } from "jotai";
+
+import { isEditModeAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
-function SaveButton({
-  isEditMode,
-  setIsEditMode,
-  setIsOnSave,
-  isRelationship,
-}) {
+function SaveButton({ setIsOnSave, isRelationship }) {
+  const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+
   return (
     <div
       className={`flex w-20 justify-center items-center
@@ -26,10 +25,5 @@ function SaveButton({
     </div>
   );
 }
-
-SaveButton.propTypes = {
-  isEditMode: PropTypes.bool.isRequired,
-  setIsEditMode: PropTypes.func.isRequired,
-};
 
 export default SaveButton;

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,12 +1,17 @@
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
-import { isEditModeAtom, isOnSaveAtom } from "../../atoms/atoms";
+import {
+  isEditModeAtom,
+  isOnSaveAtom,
+  isRelationshipAtom,
+} from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
-function SaveButton({ isRelationship }) {
+function SaveButton() {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const setIsOnSave = useSetAtom(isOnSaveAtom);
+  const isRelationship = useAtomValue(isRelationshipAtom);
 
   return (
     <div

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,17 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import {
   isEditModeAtom,
   isOnSaveAtom,
   isRelationshipAtom,
+  userAtom,
+  currentDBIdAtom,
+  changedDocAtom,
 } from "../../atoms/atoms";
+
+import fetchData from "../../utils/axios";
 
 import Button from "../shared/Button";
 
 function SaveButton() {
+  const queryClient = useQueryClient();
+
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const setIsOnSave = useSetAtom(isOnSaveAtom);
+
   const isRelationship = useAtomValue(isRelationshipAtom);
+  const { userId } = useAtomValue(userAtom);
+  const currentDBId = useAtomValue(currentDBIdAtom);
+  const changedDoc = useAtomValue(changedDocAtom);
+
+  async function handleClickSave() {
+    await fetchData(
+      "PUT",
+      `/users/${userId}/databases/${currentDBId}/documents`,
+      changedDoc,
+    );
+  }
+
+  const { mutate: fetchDocumentUpdate } = useMutation(handleClickSave, {
+    onSuccess: () => {
+      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+    },
+    refetchOnWindowFocus: false,
+  });
 
   return (
     <div
@@ -22,7 +52,10 @@ function SaveButton() {
         className={`w-20 h-8 rounded-md bg-white
         ${isEditMode ? "ring-4 ring-blue hover:bg-blue" : ""}`}
         onClick={() => {
-          setIsOnSave(true);
+          if (isEditMode) {
+            fetchDocumentUpdate();
+            setIsOnSave(false);
+          }
           setIsEditMode(!isEditMode);
         }}
       >

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,11 +1,12 @@
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 
-import { isEditModeAtom } from "../../atoms/atoms";
+import { isEditModeAtom, isOnSaveAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
-function SaveButton({ setIsOnSave, isRelationship }) {
+function SaveButton({ isRelationship }) {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+  const setIsOnSave = useSetAtom(isOnSaveAtom);
 
   return (
     <div

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -1,9 +1,14 @@
 import { useNavigate } from "react-router-dom";
+import { useAtom } from "jotai";
+
+import isListViewAtom from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
-function SwitchViewButtons({ isListView, setIsListView, isEditMode }) {
+function SwitchViewButtons({ isEditMode }) {
   const navigate = useNavigate();
+
+  const [isListView, setIsListView] = useAtom(isListViewAtom);
 
   function switchToListView() {
     setIsListView(true);

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 
-import isListViewAtom from "../../atoms/atoms";
+import { isListViewAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -1,14 +1,15 @@
 import { useNavigate } from "react-router-dom";
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
-import { isListViewAtom } from "../../atoms/atoms";
+import { isListViewAtom, isEditModeAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
-function SwitchViewButtons({ isEditMode }) {
+function SwitchViewButtons() {
   const navigate = useNavigate();
 
   const [isListView, setIsListView] = useAtom(isListViewAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   function switchToListView() {
     setIsListView(true);

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
-import { useSetAtom } from "jotai";
+import { useSetAtom, useAtomValue } from "jotai";
 
-import { isListViewAtom } from "../../atoms/atoms";
+import { isListViewAtom, isEditModeAtom } from "../../atoms/atoms";
 
 import RelationshipButton from "./RelationshipButton";
 import DocHandlerButtons from "./DocHandlerButtons";
@@ -9,7 +9,6 @@ import SwitchViewButtons from "./SwitchViewButtons";
 import Button from "../shared/Button";
 
 function Toolbar({
-  isEditMode,
   documentsIds,
   setDocumentsIds,
   isRelationship,
@@ -18,6 +17,7 @@ function Toolbar({
   const navigate = useNavigate();
 
   const setIsListView = useSetAtom(isListViewAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   function clickHandelBackButton() {
     setIsRelationship(false);
@@ -40,16 +40,14 @@ function Toolbar({
         ${isRelationship && "hidden"}`}
       >
         <RelationshipButton
-          isEditMode={isEditMode}
           isRelationship={isRelationship}
           setIsRelationship={setIsRelationship}
         />
         <DocHandlerButtons
-          isEditMode={isEditMode}
           documentsIds={documentsIds}
           setDocumentsIds={setDocumentsIds}
         />
-        <SwitchViewButtons isEditMode={isEditMode} />
+        <SwitchViewButtons />
       </div>
     </>
   );

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -12,7 +12,7 @@ import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 import Button from "../shared/Button";
 
-function Toolbar({ documentsIds, setDocumentsIds }) {
+function Toolbar() {
   const navigate = useNavigate();
 
   const [isRelationship, setIsRelationship] = useAtom(isRelationshipAtom);
@@ -40,10 +40,7 @@ function Toolbar({ documentsIds, setDocumentsIds }) {
         ${isRelationship && "hidden"}`}
       >
         <RelationshipButton />
-        <DocHandlerButtons
-          documentsIds={documentsIds}
-          setDocumentsIds={setDocumentsIds}
-        />
+        <DocHandlerButtons />
         <SwitchViewButtons />
       </div>
     </>

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,5 +1,8 @@
 import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
+import { useSetAtom } from "jotai";
+
+import isListViewAtom from "../../atoms/atoms";
 
 import RelationshipButton from "./RelationshipButton";
 import DocHandlerButtons from "./DocHandlerButtons";
@@ -7,8 +10,6 @@ import SwitchViewButtons from "./SwitchViewButtons";
 import Button from "../shared/Button";
 
 function Toolbar({
-  isListView,
-  setIsListView,
   isEditMode,
   currentDocIndex,
   setCurrentDocIndex,
@@ -18,6 +19,8 @@ function Toolbar({
   setIsRelationship,
 }) {
   const navigate = useNavigate();
+
+  const setIsListView = useSetAtom(isListViewAtom);
 
   function clickHandelBackButton() {
     setIsRelationship(false);
@@ -51,11 +54,7 @@ function Toolbar({
           documentsIds={documentsIds}
           setDocumentsIds={setDocumentsIds}
         />
-        <SwitchViewButtons
-          isEditMode={isEditMode}
-          isListView={isListView}
-          setIsListView={setIsListView}
-        />
+        <SwitchViewButtons isEditMode={isEditMode} />
       </div>
     </>
   );

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,21 +1,21 @@
 import { useNavigate } from "react-router-dom";
-import { useSetAtom, useAtomValue } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
-import { isListViewAtom, isEditModeAtom } from "../../atoms/atoms";
+import {
+  isListViewAtom,
+  isEditModeAtom,
+  isRelationshipAtom,
+} from "../../atoms/atoms";
 
 import RelationshipButton from "./RelationshipButton";
 import DocHandlerButtons from "./DocHandlerButtons";
 import SwitchViewButtons from "./SwitchViewButtons";
 import Button from "../shared/Button";
 
-function Toolbar({
-  documentsIds,
-  setDocumentsIds,
-  isRelationship,
-  setIsRelationship,
-}) {
+function Toolbar({ documentsIds, setDocumentsIds }) {
   const navigate = useNavigate();
 
+  const [isRelationship, setIsRelationship] = useAtom(isRelationshipAtom);
   const setIsListView = useSetAtom(isListViewAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
@@ -39,10 +39,7 @@ function Toolbar({
         className={`flex justify-between items-center w-full h-full mr-3 bg-black-bg
         ${isRelationship && "hidden"}`}
       >
-        <RelationshipButton
-          isRelationship={isRelationship}
-          setIsRelationship={setIsRelationship}
-        />
+        <RelationshipButton />
         <DocHandlerButtons
           documentsIds={documentsIds}
           setDocumentsIds={setDocumentsIds}

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useSetAtom } from "jotai";
 
-import isListViewAtom from "../../atoms/atoms";
+import { isListViewAtom } from "../../atoms/atoms";
 
 import RelationshipButton from "./RelationshipButton";
 import DocHandlerButtons from "./DocHandlerButtons";

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "react-router-dom";
-import PropTypes from "prop-types";
 import { useSetAtom } from "jotai";
 
 import { isListViewAtom } from "../../atoms/atoms";
@@ -11,8 +10,6 @@ import Button from "../shared/Button";
 
 function Toolbar({
   isEditMode,
-  currentDocIndex,
-  setCurrentDocIndex,
   documentsIds,
   setDocumentsIds,
   isRelationship,
@@ -49,8 +46,6 @@ function Toolbar({
         />
         <DocHandlerButtons
           isEditMode={isEditMode}
-          currentDocIndex={currentDocIndex}
-          setCurrentDocIndex={setCurrentDocIndex}
           documentsIds={documentsIds}
           setDocumentsIds={setDocumentsIds}
         />
@@ -59,10 +54,5 @@ function Toolbar({
     </>
   );
 }
-
-Toolbar.propTypes = {
-  currentDocIndex: PropTypes.number.isRequired,
-  setCurrentDocIndex: PropTypes.func.isRequired,
-};
 
 export default Toolbar;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,18 +1,22 @@
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
+import { useSetAtom } from "jotai";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
-import PropTypes from "prop-types";
 
 import fetchData from "../utils/axios";
 import { firebaseAuth } from "../app/firebaseAuth";
 import useLoading from "../utils/useLoading";
 
+import { userAtom } from "../atoms/atoms";
+
 import Button from "./shared/Button";
 import Loading from "./shared/Loading";
 
-function Login({ setUser }) {
+function Login() {
   const navigate = useNavigate();
   const googleProvider = new GoogleAuthProvider();
+
+  const setUser = useSetAtom(userAtom);
 
   async function handleGoogleLogin() {
     const result = await signInWithPopup(firebaseAuth, googleProvider);
@@ -75,9 +79,5 @@ function Login({ setUser }) {
     </div>
   );
 }
-
-Login.propTypes = {
-  setUser: PropTypes.func.isRequired,
-};
 
 export default Login;

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -1,18 +1,31 @@
 import { useQuery } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
-import PropTypes from "prop-types";
+import { useAtomValue, useAtom } from "jotai";
 
 import fetchData from "../../../utils/axios";
 import getTodaysDate from "../../../utils/getTodaysDate";
 
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, userAtom, fieldsAtom } from "../../../atoms/atoms";
 
 import InputWrapper from "../SharedItems/InputWrapper";
 import Loading from "../../shared/Loading";
 
-function AddDocInputList({ updateFieldValue, setFields }) {
+function AddDocInputList() {
+  const [fields, setFields] = useAtom(fieldsAtom);
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+
+  function adjustTextareaHeight(event) {
+    event.target.style.height = `${event.target.scrollHeight}px`;
+  }
+
+  function updateFieldValue(index, event) {
+    const newFields = [...fields];
+
+    newFields[index].fieldValue = event.target.value;
+
+    setFields(newFields);
+    adjustTextareaHeight(event);
+  }
 
   async function getDatabase() {
     const response = await fetchData(
@@ -75,10 +88,5 @@ function AddDocInputList({ updateFieldValue, setFields }) {
     );
   });
 }
-
-AddDocInputList.propTypes = {
-  updateFieldValue: PropTypes.func.isRequired,
-  setFields: PropTypes.func.isRequired,
-};
 
 export default AddDocInputList;

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -1,18 +1,19 @@
 import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 import getTodaysDate from "../../../utils/getTodaysDate";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import InputWrapper from "../SharedItems/InputWrapper";
 import Loading from "../../shared/Loading";
 
 function AddDocInputList({ updateFieldValue, setFields }) {
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDatabase() {
     const response = await fetchData(

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
@@ -6,13 +5,13 @@ import PropTypes from "prop-types";
 import fetchData from "../../../utils/axios";
 import getTodaysDate from "../../../utils/getTodaysDate";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+
 import InputWrapper from "../SharedItems/InputWrapper";
 import Loading from "../../shared/Loading";
 
 function AddDocInputList({ updateFieldValue, setFields }) {
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDatabase() {

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -10,6 +10,7 @@ import {
   documentsIdsAtom,
   userAtom,
   showAddDocumentModalAtom,
+  fieldsAtom,
 } from "../../../atoms/atoms";
 
 import Button from "../../shared/Button";
@@ -22,30 +23,16 @@ import InputsArea from "../SharedItems/InputsArea";
 import Loading from "../../shared/Loading";
 
 function AddDocumentModal() {
-  const [fields, setFields] = useState([]);
-
   const queryClient = useQueryClient();
-
-  const { userId } = useAtomValue(userAtom);
 
   const [documentsIds, setDocumentsIds] = useAtom(documentsIdsAtom);
 
+  const { userId } = useAtomValue(userAtom);
+  const fields = useAtomValue(fieldsAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
   const setShowAddDocumentModal = useSetAtom(showAddDocumentModalAtom);
-
-  function adjustTextareaHeight(event) {
-    event.target.style.height = `${event.target.scrollHeight}px`;
-  }
-
-  function updateFieldValue(index, event) {
-    const newFields = [...fields];
-
-    newFields[index].fieldValue = event.target.value;
-
-    setFields(newFields);
-    adjustTextareaHeight(event);
-  }
 
   function addNewDocumentId(newId) {
     const newFields = [...documentsIds];
@@ -90,10 +77,7 @@ function AddDocumentModal() {
         <Title>Add New Document</Title>
         <Content>
           <InputsArea>
-            <AddDocInputList
-              updateFieldValue={updateFieldValue}
-              setFields={setFields}
-            />
+            <AddDocInputList />
           </InputsArea>
         </Content>
         <Button

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
@@ -9,9 +9,9 @@ import {
   currentDBIdAtom,
   currentDocIndexAtom,
   documentsIdsAtom,
+  userAtom,
 } from "../../../atoms/atoms";
 
-import UserContext from "../../../context/UserContext";
 import Button from "../../shared/Button";
 import Modal from "../../shared/Modal";
 import Title from "../SharedItems/Title";
@@ -26,7 +26,7 @@ function AddDocumentModal({ closeModal }) {
 
   const queryClient = useQueryClient();
 
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   const [documentsIds, setDocumentsIds] = useAtom(documentsIdsAtom);
 

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -1,11 +1,11 @@
 import { useState, useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useSetAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Button from "../../shared/Button";
 import Modal from "../../shared/Modal";
@@ -16,16 +16,12 @@ import Content from "../SharedItems/Content";
 import InputsArea from "../SharedItems/InputsArea";
 import Loading from "../../shared/Loading";
 
-function AddDocumentModal({
-  closeModal,
-  setDocumentsIds,
-  setCurrentDocIndex,
-  documentsIds,
-}) {
+function AddDocumentModal({ closeModal, setDocumentsIds, documentsIds }) {
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
 
   const [fields, setFields] = useState([]);
 

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -1,11 +1,12 @@
 import { useState, useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import Button from "../../shared/Button";
 import Modal from "../../shared/Modal";
 import Title from "../SharedItems/Title";
@@ -24,7 +25,7 @@ function AddDocumentModal({
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [fields, setFields] = useState([]);
 

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -1,11 +1,16 @@
 import { useState, useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useSetAtom, useAtomValue } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDocIndexAtom,
+  documentsIdsAtom,
+} from "../../../atoms/atoms";
+
 import UserContext from "../../../context/UserContext";
 import Button from "../../shared/Button";
 import Modal from "../../shared/Modal";
@@ -16,14 +21,17 @@ import Content from "../SharedItems/Content";
 import InputsArea from "../SharedItems/InputsArea";
 import Loading from "../../shared/Loading";
 
-function AddDocumentModal({ closeModal, setDocumentsIds, documentsIds }) {
+function AddDocumentModal({ closeModal }) {
+  const [fields, setFields] = useState([]);
+
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
+
+  const [documentsIds, setDocumentsIds] = useAtom(documentsIdsAtom);
+
   const currentDBId = useAtomValue(currentDBIdAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
-
-  const [fields, setFields] = useState([]);
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;

--- a/src/components/Modals/AddNewDocument/AddDocModal.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocModal.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
-import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
@@ -10,6 +9,7 @@ import {
   currentDocIndexAtom,
   documentsIdsAtom,
   userAtom,
+  showAddDocumentModalAtom,
 } from "../../../atoms/atoms";
 
 import Button from "../../shared/Button";
@@ -21,7 +21,7 @@ import Content from "../SharedItems/Content";
 import InputsArea from "../SharedItems/InputsArea";
 import Loading from "../../shared/Loading";
 
-function AddDocumentModal({ closeModal }) {
+function AddDocumentModal() {
   const [fields, setFields] = useState([]);
 
   const queryClient = useQueryClient();
@@ -32,6 +32,7 @@ function AddDocumentModal({ closeModal }) {
 
   const currentDBId = useAtomValue(currentDBIdAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
+  const setShowAddDocumentModal = useSetAtom(showAddDocumentModalAtom);
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;
@@ -71,7 +72,7 @@ function AddDocumentModal({ closeModal }) {
         setCurrentDocIndex(documentsIds.length);
 
         queryClient.refetchQueries(["dbDocumentList", currentDBId]);
-        closeModal();
+        setShowAddDocumentModal(false);
       },
       onFailure: () => {
         console.log("sending user to errorpage");
@@ -84,7 +85,7 @@ function AddDocumentModal({ closeModal }) {
   }
 
   return (
-    <Modal onClick={closeModal}>
+    <Modal onClick={() => setShowAddDocumentModal(false)}>
       <ContentWrapper>
         <Title>Add New Document</Title>
         <Content>
@@ -105,9 +106,5 @@ function AddDocumentModal({ closeModal }) {
     </Modal>
   );
 }
-
-AddDocumentModal.propTypes = {
-  closeModal: PropTypes.func.isRequired,
-};
 
 export default AddDocumentModal;

--- a/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
@@ -1,4 +1,8 @@
+import { useAtom } from "jotai";
+
 import PropTypes from "prop-types";
+
+import { dbFieldsAtom } from "../../../atoms/atoms";
 
 import Select from "../../shared/Select";
 import Button from "../../shared/Button";
@@ -8,12 +12,27 @@ import CONSTANT from "../../../constants/constant";
 
 const { MAX_FIELD_NAME_LENGTH, FIELD_TYPES } = CONSTANT;
 
-function CreateDBInputList({
-  fields,
-  updateFieldName,
-  updateFieldType,
-  handleClickDeleteField,
-}) {
+function CreateDBInputList({ updateFieldName }) {
+  const [fields, setFields] = useAtom(dbFieldsAtom);
+
+  function updateFieldType(index, event) {
+    const newFields = [...fields];
+    newFields[index].fieldType = event.target.value;
+
+    setFields(newFields);
+  }
+
+  function handleClickDeleteField(index) {
+    if (fields.length === 1) {
+      return;
+    }
+
+    const newFields = [...fields];
+    newFields.splice(index, 1);
+
+    setFields(newFields);
+  }
+
   return fields.map((element, index) => {
     return (
       <div key={element.id}>

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -5,7 +5,11 @@ import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../../utils/axios";
-import { currentDBIdAtom, isListViewAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  isListViewAtom,
+  currentDBNameAtom,
+} from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
@@ -22,7 +26,7 @@ import Loading from "../../shared/Loading";
 
 import CONSTANT from "../../../constants/constant";
 
-function CreateDBModal({ closeModal, setCurrentDBName }) {
+function CreateDBModal({ closeModal }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useContext(UserContext);
@@ -41,6 +45,7 @@ function CreateDBModal({ closeModal, setCurrentDBName }) {
 
   const setIsListView = useSetAtom(isListViewAtom);
   const setCurrentDBId = useSetAtom(currentDBIdAtom);
+  const setCurrentDBName = useSetAtom(currentDBNameAtom);
 
   function updateFieldName(index, event) {
     const newFields = [...fields];

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -1,6 +1,6 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useSetAtom } from "jotai";
+import { useSetAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -9,9 +9,9 @@ import {
   currentDBIdAtom,
   isListViewAtom,
   currentDBNameAtom,
+  userAtom,
 } from "../../../atoms/atoms";
 
-import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
 import ContentWrapper from "../SharedItems/ContentWrapper";
 import Content from "../SharedItems/Content";
@@ -29,7 +29,7 @@ import CONSTANT from "../../../constants/constant";
 function CreateDBModal({ closeModal }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   const [dbName, setdbName] = useState(null);
   const [fields, setFields] = useState([

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useSetAtom, useAtomValue } from "jotai";
+import { useSetAtom, useAtomValue, useAtom } from "jotai";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../../utils/axios";
@@ -10,6 +10,7 @@ import {
   currentDBNameAtom,
   userAtom,
   showCreateDBModalAtom,
+  dbFieldsAtom,
 } from "../../../atoms/atoms";
 
 import Modal from "../../shared/Modal";
@@ -32,13 +33,8 @@ function CreateDBModal() {
   const { userId } = useAtomValue(userAtom);
 
   const [dbName, setdbName] = useState(null);
-  const [fields, setFields] = useState([
-    {
-      id: crypto.randomUUID(),
-      fieldName: "",
-      fieldType: "Text",
-    },
-  ]);
+  const [fields, setFields] = useAtom(dbFieldsAtom);
+
   const [isDBNameEmpty, setIsDBNameEmpty] = useState(false);
   const [isFieldNameEmpty, setIsFieldNameEmpty] = useState(false);
   const [isFieldNameDuplicate, setIsFieldNameDuplicate] = useState(false);
@@ -59,13 +55,6 @@ function CreateDBModal() {
     setFields(newFields);
   }
 
-  function updateFieldType(index, event) {
-    const newFields = [...fields];
-    newFields[index].fieldType = event.target.value;
-
-    setFields(newFields);
-  }
-
   function handleClickAddField() {
     setFields([
       ...fields,
@@ -75,17 +64,6 @@ function CreateDBModal() {
         fieldType: "Text",
       },
     ]);
-  }
-
-  function handleClickDeleteField(index) {
-    if (fields.length === 1) {
-      return;
-    }
-
-    const newFields = [...fields];
-    newFields.splice(index, 1);
-
-    setFields(newFields);
   }
 
   async function fetchDatabase(newDatabase) {
@@ -188,12 +166,7 @@ function CreateDBModal() {
                 {`Database's name cannot be empty.`}
               </p>
             )}
-            <CreateDBInputList
-              fields={fields}
-              updateFieldName={updateFieldName}
-              updateFieldType={updateFieldType}
-              handleClickDeleteField={handleClickDeleteField}
-            />
+            <CreateDBInputList updateFieldName={updateFieldName} />
             {isFieldNameEmpty && (
               <p className="text-red text-sm">{`Field's name cannot be empty.`}</p>
             )}

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSetAtom, useAtomValue } from "jotai";
-import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../../utils/axios";
@@ -10,6 +9,7 @@ import {
   isListViewAtom,
   currentDBNameAtom,
   userAtom,
+  showCreateDBModalAtom,
 } from "../../../atoms/atoms";
 
 import Modal from "../../shared/Modal";
@@ -26,7 +26,7 @@ import Loading from "../../shared/Loading";
 
 import CONSTANT from "../../../constants/constant";
 
-function CreateDBModal({ closeModal }) {
+function CreateDBModal() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useAtomValue(userAtom);
@@ -46,6 +46,7 @@ function CreateDBModal({ closeModal }) {
   const setIsListView = useSetAtom(isListViewAtom);
   const setCurrentDBId = useSetAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
+  const setShowCreateDBModal = useSetAtom(showCreateDBModalAtom);
 
   function updateFieldName(index, event) {
     const newFields = [...fields];
@@ -107,7 +108,7 @@ function CreateDBModal({ closeModal }) {
 
       navigate("/dashboard/listview");
 
-      closeModal();
+      setShowCreateDBModal(false);
     },
     onFailure: () => {
       console.log("sending user to errorpage");
@@ -166,7 +167,7 @@ function CreateDBModal({ closeModal }) {
   }
 
   return (
-    <Modal onClick={closeModal}>
+    <Modal onClick={() => setShowCreateDBModal(false)}>
       <ContentWrapper>
         <Title>Create New Database</Title>
         <Content>
@@ -221,9 +222,5 @@ function CreateDBModal({ closeModal }) {
     </Modal>
   );
 }
-
-CreateDBModal.propTypes = {
-  closeModal: PropTypes.func.isRequired,
-};
 
 export default CreateDBModal;

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../../utils/axios";
-import isListViewAtom from "../../../atoms/atoms";
+import { currentDBIdAtom, isListViewAtom } from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
@@ -22,7 +22,7 @@ import Loading from "../../shared/Loading";
 
 import CONSTANT from "../../../constants/constant";
 
-function CreateDBModal({ closeModal, setCurrentDBId, setCurrentDBName }) {
+function CreateDBModal({ closeModal, setCurrentDBName }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useContext(UserContext);
@@ -40,6 +40,7 @@ function CreateDBModal({ closeModal, setCurrentDBId, setCurrentDBName }) {
   const [isFieldNameDuplicate, setIsFieldNameDuplicate] = useState(false);
 
   const setIsListView = useSetAtom(isListViewAtom);
+  const setCurrentDBId = useSetAtom(currentDBIdAtom);
 
   function updateFieldName(index, event) {
     const newFields = [...fields];
@@ -218,7 +219,6 @@ function CreateDBModal({ closeModal, setCurrentDBId, setCurrentDBName }) {
 
 CreateDBModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
-  setCurrentDBId: PropTypes.func.isRequired,
 };
 
 export default CreateDBModal;

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -1,9 +1,11 @@
 import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useSetAtom } from "jotai";
 import PropTypes from "prop-types";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchData from "../../../utils/axios";
+import isListViewAtom from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
@@ -20,12 +22,7 @@ import Loading from "../../shared/Loading";
 
 import CONSTANT from "../../../constants/constant";
 
-function CreateDBModal({
-  setIsListView,
-  closeModal,
-  setCurrentDBId,
-  setCurrentDBName,
-}) {
+function CreateDBModal({ closeModal, setCurrentDBId, setCurrentDBName }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { userId } = useContext(UserContext);
@@ -41,6 +38,8 @@ function CreateDBModal({
   const [isDBNameEmpty, setIsDBNameEmpty] = useState(false);
   const [isFieldNameEmpty, setIsFieldNameEmpty] = useState(false);
   const [isFieldNameDuplicate, setIsFieldNameDuplicate] = useState(false);
+
+  const setIsListView = useSetAtom(isListViewAtom);
 
   function updateFieldName(index, event) {
     const newFields = [...fields];

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -1,11 +1,12 @@
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import Modal from "../../shared/Modal";
 import Button from "../../shared/Button";
 import Content from "../SharedItems/Content";
@@ -23,7 +24,7 @@ function DeleteDocModal({
 }) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function deleteDocument() {
     await fetchData(

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -1,11 +1,11 @@
 import { useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
 import Button from "../../shared/Button";
@@ -16,14 +16,14 @@ import Loading from "../../shared/Loading";
 
 function DeleteDocModal({
   closeModal,
-  currentDocIndex,
   documentsIds,
-  setCurrentDocIndex,
   isLastDocument,
   setIsLastDocument,
 }) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
+
+  const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function deleteDocument() {
@@ -89,7 +89,6 @@ function DeleteDocModal({
 
 DeleteDocModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
-  currentDocIndex: PropTypes.number.isRequired,
 };
 
 export default DeleteDocModal;

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -1,4 +1,3 @@
-import { useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
@@ -9,8 +8,9 @@ import {
   currentDBIdAtom,
   currentDocIndexAtom,
   documentsIdsAtom,
+  userAtom,
 } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+
 import Modal from "../../shared/Modal";
 import Button from "../../shared/Button";
 import Content from "../SharedItems/Content";
@@ -20,7 +20,7 @@ import Loading from "../../shared/Loading";
 
 function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
   const queryClient = useQueryClient();
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useAtomValue } from "jotai";
-import PropTypes from "prop-types";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
@@ -9,6 +8,8 @@ import {
   currentDocIndexAtom,
   documentsIdsAtom,
   userAtom,
+  showDeleteDocumentModalAtom,
+  isLastDocumentAtom,
 } from "../../../atoms/atoms";
 
 import Modal from "../../shared/Modal";
@@ -18,13 +19,15 @@ import ContentWrapper from "../SharedItems/ContentWrapper";
 import Message from "../SharedItems/Message";
 import Loading from "../../shared/Loading";
 
-function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
+function DeleteDocModal() {
   const queryClient = useQueryClient();
   const { userId } = useAtomValue(userAtom);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
+  const [isLastDocument, setIsLastDocument] = useAtom(isLastDocumentAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const documentsIds = useAtomValue(documentsIdsAtom);
+  const setShowDeleteDocumentModal = useSetAtom(showDeleteDocumentModalAtom);
 
   async function deleteDocument() {
     await fetchData(
@@ -39,7 +42,7 @@ function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
       onSuccess: () => {
         queryClient.refetchQueries(["dbDocumentList", currentDBId]);
         setCurrentDocIndex(0);
-        closeModal();
+        setShowDeleteDocumentModal(false);
       },
       onFailure: () => {
         console.log("sending user to errorpage");
@@ -48,7 +51,7 @@ function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
   );
 
   function clickHandleCancel() {
-    closeModal();
+    setShowDeleteDocumentModal(false);
     setIsLastDocument(false);
   }
 
@@ -57,7 +60,7 @@ function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
   }
 
   return (
-    <Modal onClick={closeModal}>
+    <Modal onClick={() => setShowDeleteDocumentModal(false)}>
       <ContentWrapper>
         <Content>
           <Message>
@@ -86,9 +89,5 @@ function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
     </Modal>
   );
 }
-
-DeleteDocModal.propTypes = {
-  closeModal: PropTypes.func.isRequired,
-};
 
 export default DeleteDocModal;

--- a/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
+++ b/src/components/Modals/DeleteDocument/DeleteDocModal.jsx
@@ -5,7 +5,11 @@ import PropTypes from "prop-types";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDocIndexAtom,
+  documentsIdsAtom,
+} from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Modal from "../../shared/Modal";
 import Button from "../../shared/Button";
@@ -14,17 +18,13 @@ import ContentWrapper from "../SharedItems/ContentWrapper";
 import Message from "../SharedItems/Message";
 import Loading from "../../shared/Loading";
 
-function DeleteDocModal({
-  closeModal,
-  documentsIds,
-  isLastDocument,
-  setIsLastDocument,
-}) {
+function DeleteDocModal({ closeModal, isLastDocument, setIsLastDocument }) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
 
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const documentsIds = useAtomValue(documentsIdsAtom);
 
   async function deleteDocument() {
     await fetchData(

--- a/src/components/Modals/Relationship/Done.jsx
+++ b/src/components/Modals/Relationship/Done.jsx
@@ -1,15 +1,16 @@
-import { useContext } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+
+import { currentDBIdAtom } from "../../../atoms/atoms";
 
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 function Done({ closeModal }) {
   const queryClient = useQueryClient();
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   return (
     <>

--- a/src/components/Modals/Relationship/Done.jsx
+++ b/src/components/Modals/Relationship/Done.jsx
@@ -1,16 +1,22 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useSetAtom, useAtomValue } from "jotai";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  showRelationshipModalAtom,
+  relationshipStepAtom,
+} from "../../../atoms/atoms";
 
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
 
-function Done({ closeModal }) {
+function Done() {
   const queryClient = useQueryClient();
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const setShowRelationshipModal = useSetAtom(showRelationshipModalAtom);
+  const setRelationshipStep = useSetAtom(relationshipStepAtom);
 
   return (
     <>
@@ -27,7 +33,8 @@ function Done({ closeModal }) {
         onClick={() => {
           queryClient.refetchQueries(["dbDocumentList", currentDBId]);
           queryClient.refetchQueries(["dbRelationShips", currentDBId]);
-          closeModal();
+          setShowRelationshipModal(false);
+          setRelationshipStep("start");
         }}
       >
         Close

--- a/src/components/Modals/Relationship/RelationshipModal.jsx
+++ b/src/components/Modals/Relationship/RelationshipModal.jsx
@@ -1,4 +1,9 @@
-import { useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+
+import {
+  relationshipStepAtom,
+  showRelationshipModalAtom,
+} from "../../../atoms/atoms";
 
 import Modal from "../../shared/Modal";
 import ContentWrapper from "../SharedItems/ContentWrapper";
@@ -8,50 +13,20 @@ import StepTwo from "./StepTwo";
 import StepThree from "./StepThree";
 import Done from "./Done";
 
-function RelationshipModal({ closeModal, databaseName }) {
-  const [relationshipStep, setRelationshipStep] = useState("start");
-  const [relationData, setRelationData] = useState({
-    primaryFieldName: "",
-    foreignDbId: "",
-    foreignFieldName: "",
-    foreignFieldsToDisplay: [],
-    foreignDb: null,
-  });
+function RelationshipModal({ databaseName }) {
+  const relationshipStep = useAtomValue(relationshipStepAtom);
+  const setShowRelationshipModal = useSetAtom(showRelationshipModalAtom);
 
   return (
-    <Modal onClick={closeModal}>
+    <Modal onClick={() => setShowRelationshipModal(false)}>
       <ContentWrapper>
-        {relationshipStep === "start" && (
-          <Start setRelationshipStep={setRelationshipStep} />
-        )}
+        {relationshipStep === "start" && <Start />}
         {relationshipStep === "stepOne" && (
-          <StepOne
-            setRelationshipStep={setRelationshipStep}
-            databaseName={databaseName}
-            relationData={relationData}
-            setRelationData={setRelationData}
-          />
+          <StepOne databaseName={databaseName} />
         )}
-        {relationshipStep === "stepTwo" && (
-          <StepTwo
-            setRelationshipStep={setRelationshipStep}
-            relationData={relationData}
-            setRelationData={setRelationData}
-          />
-        )}
-        {relationshipStep === "stepThree" && (
-          <StepThree
-            setRelationshipStep={setRelationshipStep}
-            relationData={relationData}
-            setRelationData={setRelationData}
-          />
-        )}
-        {relationshipStep === "Done" && (
-          <Done
-            setRelationshipStep={setRelationshipStep}
-            closeModal={closeModal}
-          />
-        )}
+        {relationshipStep === "stepTwo" && <StepTwo />}
+        {relationshipStep === "stepThree" && <StepThree />}
+        {relationshipStep === "Done" && <Done />}
       </ContentWrapper>
     </Modal>
   );

--- a/src/components/Modals/Relationship/Start.jsx
+++ b/src/components/Modals/Relationship/Start.jsx
@@ -1,9 +1,14 @@
+import { useSetAtom } from "jotai";
+
+import { relationshipStepAtom } from "../../../atoms/atoms";
+
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
 import Message from "../SharedItems/Message";
 
-function Start({ setRelationshipStep }) {
+function Start() {
+  const setRelationshipStep = useSetAtom(relationshipStepAtom);
   return (
     <>
       <Title>Create Relationship Wizard</Title>

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  relationshipStepAtom,
+  userAtom,
+  relationDataAtom,
+  targetDatabasesAtom,
+} from "../../../atoms/atoms";
 
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
@@ -13,17 +19,15 @@ import Message from "../SharedItems/Message";
 import Loading from "../../shared/Loading";
 import DatabasesWizard from "./WizardItems/DatabasesWizard";
 
-function StepOne({
-  setRelationshipStep,
-  databaseName,
-  relationData,
-  setRelationData,
-}) {
-  const [targetDatabases, setTargetDatabases] = useState([]);
+function StepOne({ databaseName }) {
   const [isNotSelected, setIsNotSelected] = useState(false);
 
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const relationData = useAtomValue(relationDataAtom);
+
+  const setRelationshipStep = useSetAtom(relationshipStepAtom);
+  const setTargetDatabases = useSetAtom(targetDatabasesAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);
@@ -67,12 +71,7 @@ function StepOne({
         <p>Please choose a database that you would like to link with DBNAME</p>
       </Message>
       <Content>
-        <DatabasesWizard
-          databaseName={databaseName}
-          targetDatabases={targetDatabases}
-          relationData={relationData}
-          setRelationData={setRelationData}
-        />
+        <DatabasesWizard databaseName={databaseName} />
       </Content>
       {isNotSelected && (
         <p className="mt-2 text-red text-sm">

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,11 +1,11 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -22,7 +22,7 @@ function StepOne({
   const [targetDatabases, setTargetDatabases] = useState([]);
   const [isNotSelected, setIsNotSelected] = useState(false);
 
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDatabaseList() {

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,10 +1,11 @@
 import { useState, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -22,7 +23,7 @@ function StepOne({
   const [isNotSelected, setIsNotSelected] = useState(false);
 
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -1,9 +1,14 @@
 import { useMutation } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  userAtom,
+  relationshipStepAtom,
+  relationDataAtom,
+} from "../../../atoms/atoms";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -11,9 +16,11 @@ import Message from "../SharedItems/Message";
 import Content from "../SharedItems/Content";
 import FieldWizard from "./WizardItems/FieldsWizard";
 
-function StepThree({ setRelationshipStep, relationData, setRelationData }) {
+function StepThree() {
+  const [relationData, setRelationData] = useAtom(relationDataAtom);
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const setRelationshipStep = useSetAtom(relationshipStepAtom);
 
   const targetDb = relationData.foreignDb;
 
@@ -70,8 +77,6 @@ function StepThree({ setRelationshipStep, relationData, setRelationData }) {
           <FieldWizard
             fields={targetDb.documents[0].fields}
             databaseName={targetDb.name}
-            relationData={relationData}
-            setRelationData={setRelationData}
             databaseType="portal"
           />
         </div>

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -1,10 +1,11 @@
 import { useContext } from "react";
 import { useMutation } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -14,7 +15,7 @@ import FieldWizard from "./WizardItems/FieldsWizard";
 
 function StepThree({ setRelationshipStep, relationData, setRelationData }) {
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const targetDb = relationData.foreignDb;
 

--- a/src/components/Modals/Relationship/StepThree.jsx
+++ b/src/components/Modals/Relationship/StepThree.jsx
@@ -1,11 +1,9 @@
-import { useContext } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -14,7 +12,7 @@ import Content from "../SharedItems/Content";
 import FieldWizard from "./WizardItems/FieldsWizard";
 
 function StepThree({ setRelationshipStep, relationData, setRelationData }) {
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   const targetDb = relationData.foreignDb;

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -2,11 +2,16 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  userAtom,
+  relationshipStepAtom,
+  relationDataAtom,
+} from "../../../atoms/atoms";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -14,10 +19,14 @@ import Message from "../SharedItems/Message";
 import FieldWizard from "./WizardItems/FieldsWizard";
 import Loading from "../../shared/Loading";
 
-function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
+function StepTwo() {
+  const [isNotSelected, setIsNotSelected] = useState(false);
+  const [relationData, setRelationData] = useAtom(relationDataAtom);
+
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
-  const [isNotSelected, setIsNotSelected] = useState(false);
+
+  const setRelationshipStep = useSetAtom(relationshipStepAtom);
 
   const databases = {};
 
@@ -86,8 +95,6 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
           <FieldWizard
             fields={databases.baseDb.documents[0].fields}
             databaseName={databases.baseDb.name}
-            relationData={relationData}
-            setRelationData={setRelationData}
             databaseType="base"
           />
           <div className="flex items-center h-[160px] my-10">
@@ -102,8 +109,6 @@ function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
           <FieldWizard
             fields={databases.targetDb.documents[0].fields}
             databaseName={databases.targetDb.name}
-            relationData={relationData}
-            setRelationData={setRelationData}
             databaseType="target"
           />
         </div>

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -16,7 +15,7 @@ import FieldWizard from "./WizardItems/FieldsWizard";
 import Loading from "../../shared/Loading";
 
 function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const [isNotSelected, setIsNotSelected] = useState(false);
 

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -2,11 +2,12 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useContext, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -16,7 +17,7 @@ import Loading from "../../shared/Loading";
 
 function StepTwo({ setRelationshipStep, relationData, setRelationData }) {
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
   const [isNotSelected, setIsNotSelected] = useState(false);
 
   const databases = {};

--- a/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
@@ -1,14 +1,14 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
 
-function DatabasesWizard({
-  databaseName,
-  targetDatabases,
-  relationData,
-  setRelationData,
-}) {
+import { relationDataAtom, targetDatabasesAtom } from "../../../../atoms/atoms";
+
+function DatabasesWizard({ databaseName }) {
   const [isSelected, setIsSelected] = useState("");
+  const [relationData, setRelationData] = useAtom(relationDataAtom);
+  const targetDatabases = useAtomValue(targetDatabasesAtom);
 
   function handleDatabaseClick(id) {
     setIsSelected(id);

--- a/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/FieldsWizard.jsx
@@ -1,17 +1,15 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useState } from "react";
+import { useAtom } from "jotai";
 
-function FieldWizard({
-  fields,
-  databaseName,
-  relationData,
-  setRelationData,
-  databaseType,
-}) {
+import { relationDataAtom } from "../../../../atoms/atoms";
+
+function FieldWizard({ fields, databaseName, databaseType }) {
   const [isSelected, setIsSelected] = useState("");
   const [updatedFields, setUpdatedFields] = useState(fields);
   const [selectedFieldNames, setSelectedFieldNames] = useState([]);
+  const [relationData, setRelationData] = useAtom(relationDataAtom);
 
   function moveToFirstIndex(id) {
     if (databaseType === "portal") {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -109,8 +109,6 @@ function Sidebar() {
       queryClient.refetchQueries(["dbDocumentList", clickedDBId]);
     }
 
-    console.log("this is DB!!", databases);
-
     return databases.map(element => {
       return (
         <div

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import fetchData from "../utils/axios";
 
@@ -8,6 +8,7 @@ import {
   currentDBIdAtom,
   currentDBNameAtom,
   currentDocIndexAtom,
+  isEditModeAtom,
 } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
 
@@ -16,7 +17,6 @@ import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
 function Sidebar({
-  isEditMode,
   isInitial,
   setIsInitial,
   isRelationship,
@@ -29,6 +29,7 @@ function Sidebar({
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,6 +11,7 @@ import {
   isEditModeAtom,
   isRelationshipAtom,
   relationshipsDataAtom,
+  isInitialAtom,
 } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
 
@@ -18,12 +19,13 @@ import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
-function Sidebar({ isInitial, setIsInitial }) {
+function Sidebar() {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   const { userId, username } = useContext(UserContext);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
+  const [isInitial, setIsInitial] = useAtom(isInitialAtom);
 
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
@@ -12,8 +12,8 @@ import {
   isRelationshipAtom,
   relationshipsDataAtom,
   isInitialAtom,
+  userAtom,
 } from "../atoms/atoms";
-import UserContext from "../context/UserContext";
 
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
@@ -23,7 +23,7 @@ function Sidebar() {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
-  const { userId, username } = useContext(UserContext);
+  const { userId, username } = useAtomValue(userAtom);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
   const [isInitial, setIsInitial] = useAtom(isInitialAtom);
 
@@ -108,6 +108,8 @@ function Sidebar() {
       queryClient.refetchQueries(["userDb"]);
       queryClient.refetchQueries(["dbDocumentList", clickedDBId]);
     }
+
+    console.log("this is DB!!", databases);
 
     return databases.map(element => {
       return (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   relationshipsDataAtom,
   isInitialAtom,
   userAtom,
+  showCreateDBModalAtom,
 } from "../atoms/atoms";
 
 import Button from "./shared/Button";
@@ -21,11 +22,13 @@ import Loading from "./shared/Loading";
 
 function Sidebar() {
   const queryClient = useQueryClient();
-  const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   const { userId, username } = useAtomValue(userAtom);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
   const [isInitial, setIsInitial] = useAtom(isInitialAtom);
+  const [showCreateDBModal, setShowCreateDBModal] = useAtom(
+    showCreateDBModalAtom,
+  );
 
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
@@ -175,9 +178,7 @@ function Sidebar() {
           New Database
         </Button>
       </div>
-      {showCreateDBModal && (
-        <CreateDBModal closeModal={() => setShowCreateDBModal(false)} />
-      )}
+      {showCreateDBModal && <CreateDBModal />}
     </div>
   );
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -4,8 +4,13 @@ import { useAtom, useSetAtom } from "jotai";
 
 import fetchData from "../utils/axios";
 
-import { currentDBIdAtom, currentDBNameAtom } from "../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDBNameAtom,
+  currentDocIndexAtom,
+} from "../atoms/atoms";
 import UserContext from "../context/UserContext";
+
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
@@ -14,7 +19,6 @@ function Sidebar({
   isEditMode,
   isInitial,
   setIsInitial,
-  setCurrentDocIndex,
   isRelationship,
   setRelationshipsData,
 }) {
@@ -24,6 +28,7 @@ function Sidebar({
   const { userId, username } = useContext(UserContext);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
+  const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,10 @@
 import { useState, useContext } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 
 import fetchData from "../utils/axios";
 
-import { currentDBIdAtom } from "../atoms/atoms";
+import { currentDBIdAtom, currentDBNameAtom } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
@@ -15,7 +15,6 @@ function Sidebar({
   isInitial,
   setIsInitial,
   setCurrentDocIndex,
-  setCurrentDBName,
   isRelationship,
   setRelationshipsData,
 }) {
@@ -24,6 +23,7 @@ function Sidebar({
 
   const { userId, username } = useContext(UserContext);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
+  const setCurrentDBName = useSetAtom(currentDBNameAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);
@@ -167,11 +167,7 @@ function Sidebar({
         </Button>
       </div>
       {showCreateDBModal && (
-        <CreateDBModal
-          closeModal={() => setShowCreateDBModal(false)}
-          setCurrentDBId={setCurrentDBId}
-          setCurrentDBName={setCurrentDBName}
-        />
+        <CreateDBModal closeModal={() => setShowCreateDBModal(false)} />
       )}
     </div>
   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   isRelationshipAtom,
+  relationshipsDataAtom,
 } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
 
@@ -17,14 +18,17 @@ import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
-function Sidebar({ isInitial, setIsInitial, setRelationshipsData }) {
+function Sidebar({ isInitial, setIsInitial }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   const { userId, username } = useContext(UserContext);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
+
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
+  const setRelationshipsData = useSetAtom(relationshipsDataAtom);
+
   const isEditMode = useAtomValue(isEditModeAtom);
   const isRelationship = useAtomValue(isRelationshipAtom);
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,6 +9,7 @@ import {
   currentDBNameAtom,
   currentDocIndexAtom,
   isEditModeAtom,
+  isRelationshipAtom,
 } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
 
@@ -16,12 +17,7 @@ import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
-function Sidebar({
-  isInitial,
-  setIsInitial,
-  isRelationship,
-  setRelationshipsData,
-}) {
+function Sidebar({ isInitial, setIsInitial, setRelationshipsData }) {
   const queryClient = useQueryClient();
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
@@ -30,6 +26,7 @@ function Sidebar({
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
+  const isRelationship = useAtomValue(isRelationshipAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,18 +1,17 @@
 import { useState, useContext } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtom } from "jotai";
 
-import PropTypes from "prop-types";
 import fetchData from "../utils/axios";
 
+import { currentDBIdAtom } from "../atoms/atoms";
 import UserContext from "../context/UserContext";
-import CurrentDBIdContext from "../context/CurrentDBIdContext";
 import Button from "./shared/Button";
 import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
 function Sidebar({
   isEditMode,
-  setCurrentDBId,
   isInitial,
   setIsInitial,
   setCurrentDocIndex,
@@ -24,7 +23,7 @@ function Sidebar({
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   const { userId, username } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);
@@ -177,9 +176,5 @@ function Sidebar({
     </div>
   );
 }
-
-Sidebar.propTypes = {
-  setCurrentDBId: PropTypes.func.isRequired,
-};
 
 export default Sidebar;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,7 +11,6 @@ import CreateDBModal from "./Modals/CreateNewDatabase/CreateDBModal";
 import Loading from "./shared/Loading";
 
 function Sidebar({
-  setIsListView,
   isEditMode,
   setCurrentDBId,
   isInitial,
@@ -173,7 +172,6 @@ function Sidebar({
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
           setCurrentDBName={setCurrentDBName}
-          setIsListView={setIsListView}
         />
       )}
     </div>

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -1,9 +1,10 @@
 import { useState, useContext, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import PropTypes from "prop-types";
+import { useAtomValue } from "jotai";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 import Loading from "../../shared/Loading";
 import Elements from "./Elements";
 
@@ -36,7 +37,7 @@ function DetailView({
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   if (canvasElement) {
     canvasRect = canvasElement.getBoundingClientRect();

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -1,9 +1,12 @@
 import { useState, useContext, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import PropTypes from "prop-types";
 import { useAtomValue } from "jotai";
 
-import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDocIndexAtom,
+  isEditModeAtom,
+} from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Loading from "../../shared/Loading";
 import Elements from "./Elements";
@@ -16,8 +19,6 @@ import getTodaysDate from "../../../utils/getTodaysDate";
 import CONSTANT from "../../../constants/constant";
 
 function DetailView({
-  isEditMode,
-  setIsEditMode,
   setDocumentsIds,
   isOnSave,
   setIsOnSave,
@@ -38,6 +39,7 @@ function DetailView({
   const { userId } = useContext(UserContext);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   if (canvasElement) {
     canvasRect = canvasElement.getBoundingClientRect();
@@ -216,8 +218,6 @@ function DetailView({
         setDraggingElement={setDraggingElement}
         relationshipsData={relationshipsData}
         setRelationshipsData={setRelationshipsData}
-        isEditMode={isEditMode}
-        setIsEditMode={setIsEditMode}
         fetchDeleteRelationship={fetchDeleteRelationship}
         docData={docData}
         primaryField={primaryField}
@@ -228,10 +228,5 @@ function DetailView({
     </div>
   );
 }
-
-DetailView.propTypes = {
-  isEditMode: PropTypes.bool.isRequired,
-  setIsEditMode: PropTypes.func.isRequired,
-};
 
 export default DetailView;

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -7,6 +7,7 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   isOnSaveAtom,
+  relationshipsDataAtom,
 } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Loading from "../../shared/Loading";
@@ -19,11 +20,7 @@ import movePortal from "../../../utils/movePortal";
 import getTodaysDate from "../../../utils/getTodaysDate";
 import CONSTANT from "../../../constants/constant";
 
-function DetailView({
-  setDocumentsIds,
-  relationshipsData,
-  setRelationshipsData,
-}) {
+function DetailView({ setDocumentsIds }) {
   const canvasRef = useRef(null);
   const canvasElement = canvasRef.current;
   let canvasRect = null;
@@ -36,7 +33,12 @@ function DetailView({
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
+
   const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
+  const [relationshipsData, setRelationshipsData] = useAtom(
+    relationshipsDataAtom,
+  );
+
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
@@ -216,8 +218,6 @@ function DetailView({
         handleMouseUp={handleMouseUp}
         draggingElement={draggingElement}
         setDraggingElement={setDraggingElement}
-        relationshipsData={relationshipsData}
-        setRelationshipsData={setRelationshipsData}
         fetchDeleteRelationship={fetchDeleteRelationship}
         docData={docData}
         primaryField={primaryField}

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import {
   currentDBIdAtom,
@@ -8,6 +8,7 @@ import {
   isEditModeAtom,
   isOnSaveAtom,
   relationshipsDataAtom,
+  documentsIdsAtom,
 } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Loading from "../../shared/Loading";
@@ -20,7 +21,7 @@ import movePortal from "../../../utils/movePortal";
 import getTodaysDate from "../../../utils/getTodaysDate";
 import CONSTANT from "../../../constants/constant";
 
-function DetailView({ setDocumentsIds }) {
+function DetailView() {
   const canvasRef = useRef(null);
   const canvasElement = canvasRef.current;
   let canvasRect = null;
@@ -42,6 +43,8 @@ function DetailView({ setDocumentsIds }) {
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
+
+  const setDocumentsIds = useSetAtom(documentsIdsAtom);
 
   if (canvasElement) {
     canvasRect = canvasElement.getBoundingClientRect();

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -22,7 +22,6 @@ import fetchData from "../../../utils/axios";
 import useLoading from "../../../utils/useLoading";
 import moveField from "../../../utils/moveField";
 import movePortal from "../../../utils/movePortal";
-import getTodaysDate from "../../../utils/getTodaysDate";
 import CONSTANT from "../../../constants/constant";
 
 function DetailView() {
@@ -98,34 +97,6 @@ function DetailView() {
     return <Loading />;
   }
 
-  function updateDateModified(newDocData, fields) {
-    const dateModifiedFieldIndex = fields.findIndex(
-      field => field.fieldType === "Date modified",
-    );
-
-    if (dateModifiedFieldIndex !== -1) {
-      newDocData[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
-        getTodaysDate();
-    }
-  }
-
-  function updateFieldValue(index, event) {
-    const newDocData = [...docData];
-
-    newDocData[currentDocIndex].fields[index].fieldValue = event.target.value;
-
-    updateDateModified(newDocData, newDocData[currentDocIndex].fields);
-    setDocData(newDocData);
-  }
-
-  function updateFieldRows(index, value) {
-    const newDocData = [...docData];
-
-    newDocData[currentDocIndex].fields[index].rows = value;
-
-    setDocData(newDocData);
-  }
-
   function handleMouseUp() {
     setDraggingElement(null);
   }
@@ -169,10 +140,7 @@ function DetailView() {
       onMouseUp={handleMouseUp}
       ref={canvasRef}
     >
-      <Elements
-        updateFieldValue={updateFieldValue}
-        updateFieldRows={updateFieldRows}
-      />
+      <Elements />
     </div>
   );
 }

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -1,11 +1,12 @@
 import { useState, useContext, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
 import {
   currentDBIdAtom,
   currentDocIndexAtom,
   isEditModeAtom,
+  isOnSaveAtom,
 } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Loading from "../../shared/Loading";
@@ -20,8 +21,6 @@ import CONSTANT from "../../../constants/constant";
 
 function DetailView({
   setDocumentsIds,
-  isOnSave,
-  setIsOnSave,
   relationshipsData,
   setRelationshipsData,
 }) {
@@ -37,6 +36,7 @@ function DetailView({
   const queryClient = useQueryClient();
 
   const { userId } = useContext(UserContext);
+  const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const isEditMode = useAtomValue(isEditModeAtom);

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import PropTypes from "prop-types";
 import { useAtomValue } from "jotai";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
 import Loading from "../../shared/Loading";
 import Elements from "./Elements";
@@ -18,7 +18,6 @@ import CONSTANT from "../../../constants/constant";
 function DetailView({
   isEditMode,
   setIsEditMode,
-  currentDocIndex,
   setDocumentsIds,
   isOnSave,
   setIsOnSave,
@@ -38,6 +37,7 @@ function DetailView({
 
   const { userId } = useContext(UserContext);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
 
   if (canvasElement) {
     canvasRect = canvasElement.getBoundingClientRect();
@@ -220,7 +220,6 @@ function DetailView({
         setIsEditMode={setIsEditMode}
         fetchDeleteRelationship={fetchDeleteRelationship}
         docData={docData}
-        currentDocIndex={currentDocIndex}
         primaryField={primaryField}
         updateFieldValue={updateFieldValue}
         updateFieldRows={updateFieldRows}

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useRef } from "react";
+import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
@@ -9,8 +9,9 @@ import {
   isOnSaveAtom,
   relationshipsDataAtom,
   documentsIdsAtom,
+  userAtom,
 } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+
 import Loading from "../../shared/Loading";
 import Elements from "./Elements";
 
@@ -33,7 +34,7 @@ function DetailView() {
 
   const queryClient = useQueryClient();
 
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
 
   const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
   const [relationshipsData, setRelationshipsData] = useAtom(

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -1,3 +1,7 @@
+import { useAtomValue } from "jotai";
+
+import { currentDocIndexAtom } from "../../../atoms/atoms";
+
 import FieldList from "./FieldList";
 import Portal from "./Portal";
 
@@ -10,12 +14,13 @@ function Elements({
   setIsEditMode,
   fetchDeleteRelationship,
   docData,
-  currentDocIndex,
   primaryField,
   updateFieldValue,
   updateFieldRows,
   setElementScale,
 }) {
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+
   return (
     <>
       {relationshipsData &&
@@ -31,7 +36,6 @@ function Elements({
               setIsEditMode={setIsEditMode}
               handleClickDelete={fetchDeleteRelationship}
               docData={docData}
-              currentDocIndex={currentDocIndex}
               primaryField={primaryField}
               relationshipsData={relationshipsData}
               setElementScale={setElementScale}

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -14,9 +14,9 @@ function Elements() {
         relationshipsData.map((relationship, index) => {
           return (
             <Portal
-              key={relationship._id}
               index={index}
               relationship={relationship}
+              key={relationship._id}
             />
           );
         })}

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -1,6 +1,9 @@
 import { useAtomValue } from "jotai";
 
-import { currentDocIndexAtom } from "../../../atoms/atoms";
+import {
+  currentDocIndexAtom,
+  relationshipsDataAtom,
+} from "../../../atoms/atoms";
 
 import FieldList from "./FieldList";
 import Portal from "./Portal";
@@ -8,8 +11,6 @@ import Portal from "./Portal";
 function Elements({
   draggingElement,
   setDraggingElement,
-  relationshipsData,
-  setRelationshipsData,
   fetchDeleteRelationship,
   docData,
   primaryField,
@@ -18,6 +19,7 @@ function Elements({
   setElementScale,
 }) {
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   return (
     <>
@@ -28,12 +30,10 @@ function Elements({
               index={index}
               key={relationship._id}
               relationship={relationship}
-              setRelationshipsData={setRelationshipsData}
               setDraggingElement={setDraggingElement}
               handleClickDelete={fetchDeleteRelationship}
               docData={docData}
               primaryField={primaryField}
-              relationshipsData={relationshipsData}
               setElementScale={setElementScale}
             />
           );

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -10,8 +10,6 @@ function Elements({
   setDraggingElement,
   relationshipsData,
   setRelationshipsData,
-  isEditMode,
-  setIsEditMode,
   fetchDeleteRelationship,
   docData,
   primaryField,
@@ -32,8 +30,6 @@ function Elements({
               relationship={relationship}
               setRelationshipsData={setRelationshipsData}
               setDraggingElement={setDraggingElement}
-              isEditMode={isEditMode}
-              setIsEditMode={setIsEditMode}
               handleClickDelete={fetchDeleteRelationship}
               docData={docData}
               primaryField={primaryField}
@@ -48,10 +44,8 @@ function Elements({
             document={docData[currentDocIndex]}
             draggingElement={draggingElement}
             setDraggingElement={setDraggingElement}
-            isEditMode={isEditMode}
             updateFieldValue={updateFieldValue}
             updateFieldRows={updateFieldRows}
-            setIsEditMode={setIsEditMode}
             setElementScale={setElementScale}
           />
         )}

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -5,7 +5,7 @@ import { relationshipsDataAtom } from "../../../atoms/atoms";
 import FieldList from "./FieldList";
 import Portal from "./Portal";
 
-function Elements({ updateFieldValue, updateFieldRows }) {
+function Elements() {
   const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   return (
@@ -21,10 +21,7 @@ function Elements({ updateFieldValue, updateFieldRows }) {
           );
         })}
       <div className="flex flex-col absolute">
-        <FieldList
-          updateFieldValue={updateFieldValue}
-          updateFieldRows={updateFieldRows}
-        />
+        <FieldList />
       </div>
     </>
   );

--- a/src/components/contents/DetailViewItems/Elements.jsx
+++ b/src/components/contents/DetailViewItems/Elements.jsx
@@ -1,24 +1,11 @@
 import { useAtomValue } from "jotai";
 
-import {
-  currentDocIndexAtom,
-  relationshipsDataAtom,
-} from "../../../atoms/atoms";
+import { relationshipsDataAtom } from "../../../atoms/atoms";
 
 import FieldList from "./FieldList";
 import Portal from "./Portal";
 
-function Elements({
-  draggingElement,
-  setDraggingElement,
-  fetchDeleteRelationship,
-  docData,
-  primaryField,
-  updateFieldValue,
-  updateFieldRows,
-  setElementScale,
-}) {
-  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+function Elements({ updateFieldValue, updateFieldRows }) {
   const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   return (
@@ -27,28 +14,17 @@ function Elements({
         relationshipsData.map((relationship, index) => {
           return (
             <Portal
-              index={index}
               key={relationship._id}
+              index={index}
               relationship={relationship}
-              setDraggingElement={setDraggingElement}
-              handleClickDelete={fetchDeleteRelationship}
-              docData={docData}
-              primaryField={primaryField}
-              setElementScale={setElementScale}
             />
           );
         })}
       <div className="flex flex-col absolute">
-        {docData[currentDocIndex] && (
-          <FieldList
-            document={docData[currentDocIndex]}
-            draggingElement={draggingElement}
-            setDraggingElement={setDraggingElement}
-            updateFieldValue={updateFieldValue}
-            updateFieldRows={updateFieldRows}
-            setElementScale={setElementScale}
-          />
-        )}
+        <FieldList
+          updateFieldValue={updateFieldValue}
+          updateFieldRows={updateFieldRows}
+        />
       </div>
     </>
   );

--- a/src/components/contents/DetailViewItems/FieldFooter.jsx
+++ b/src/components/contents/DetailViewItems/FieldFooter.jsx
@@ -1,6 +1,21 @@
+import { useAtom, useAtomValue } from "jotai";
+
+import { docDataAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+
 import Button from "../../shared/Button";
 
-function FieldFooter({ index, updateFieldRows }) {
+function FieldFooter({ index }) {
+  const [docData, setDocData] = useAtom(docDataAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+
+  function updateFieldRows(fieldIndex, value) {
+    const newDocData = [...docData];
+
+    newDocData[currentDocIndex].fields[fieldIndex].rows = value;
+
+    setDocData(newDocData);
+  }
+
   return (
     <div className="flex justify-between w-full p-1 bg-black-bg">
       <div className="flex">

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -1,21 +1,27 @@
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
-import { isEditModeAtom } from "../../../atoms/atoms";
+import {
+  isEditModeAtom,
+  docDataAtom,
+  currentDocIndexAtom,
+  draggingElementAtom,
+  elementScaleAtom,
+} from "../../../atoms/atoms";
 
 import FieldFooter from "./FieldFooter";
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-function FieldList({
-  document,
-  updateFieldValue,
-  draggingElement,
-  setDraggingElement,
-  updateFieldRows,
-  setElementScale,
-}) {
+function FieldList({ updateFieldValue, updateFieldRows }) {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+  const [draggingElement, setDraggingElement] = useAtom(draggingElementAtom);
 
-  return document.fields.map((element, index) => {
+  const setElementScale = useSetAtom(elementScaleAtom);
+
+  const docData = useAtomValue(docDataAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const document = docData[currentDocIndex];
+
+  return document?.fields.map((element, index) => {
     return (
       <div
         key={element.fieldName}

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -8,18 +8,48 @@ import {
   elementScaleAtom,
 } from "../../../atoms/atoms";
 
+import getTodaysDate from "../../../utils/getTodaysDate";
+
 import FieldFooter from "./FieldFooter";
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-function FieldList({ updateFieldValue, updateFieldRows }) {
+function FieldList() {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const [draggingElement, setDraggingElement] = useAtom(draggingElementAtom);
+  const [docData, setDocData] = useAtom(docDataAtom);
 
   const setElementScale = useSetAtom(elementScaleAtom);
 
-  const docData = useAtomValue(docDataAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const document = docData[currentDocIndex];
+
+  function updateDateModified(newDocData, fields) {
+    const dateModifiedFieldIndex = fields.findIndex(
+      field => field.fieldType === "Date modified",
+    );
+
+    if (dateModifiedFieldIndex !== -1) {
+      newDocData[currentDocIndex].fields[dateModifiedFieldIndex].fieldValue =
+        getTodaysDate();
+    }
+  }
+
+  function updateFieldValue(index, event) {
+    const newDocData = [...docData];
+
+    newDocData[currentDocIndex].fields[index].fieldValue = event.target.value;
+
+    updateDateModified(newDocData, newDocData[currentDocIndex].fields);
+    setDocData(newDocData);
+  }
+
+  function updateFieldRows(index, value) {
+    const newDocData = [...docData];
+
+    newDocData[currentDocIndex].fields[index].rows = value;
+
+    setDocData(newDocData);
+  }
 
   return document?.fields.map((element, index) => {
     return (

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -43,14 +43,6 @@ function FieldList() {
     setDocData(newDocData);
   }
 
-  function updateFieldRows(index, value) {
-    const newDocData = [...docData];
-
-    newDocData[currentDocIndex].fields[index].rows = value;
-
-    setDocData(newDocData);
-  }
-
   return document?.fields.map((element, index) => {
     return (
       <div
@@ -97,10 +89,7 @@ function FieldList() {
               />
               <div className="hidden peer-hover:flex hover:flex">
                 {isEditMode && !draggingElement && (
-                  <FieldFooter
-                    index={index}
-                    updateFieldRows={updateFieldRows}
-                  />
+                  <FieldFooter index={index} />
                 )}
               </div>
             </div>

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -1,16 +1,20 @@
+import { useAtom } from "jotai";
+
+import { isEditModeAtom } from "../../../atoms/atoms";
+
 import FieldFooter from "./FieldFooter";
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 function FieldList({
   document,
-  isEditMode,
   updateFieldValue,
-  setIsEditMode,
   draggingElement,
   setDraggingElement,
   updateFieldRows,
   setElementScale,
 }) {
+  const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+
   return document.fields.map((element, index) => {
     return (
       <div

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import { useQuery } from "@tanstack/react-query";
-import { useContext } from "react";
 import { useAtom, useAtomValue } from "jotai";
 
 import {
@@ -8,9 +7,9 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   relationshipsDataAtom,
+  userAtom,
 } from "../../../atoms/atoms";
 
-import UserContext from "../../../context/UserContext";
 import fetchData from "../../../utils/axios";
 
 import Loading from "../../shared/Loading";
@@ -28,7 +27,7 @@ function Portal({
   primaryField,
   setElementScale,
 }) {
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
 
   const currentDBId = useAtomValue(currentDBIdAtom);

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,22 +1,18 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import {
   currentDBIdAtom,
-  currentDocIndexAtom,
   isEditModeAtom,
   relationshipsDataAtom,
   userAtom,
-  docDataAtom,
-  primaryFieldAtom,
   draggingElementAtom,
   elementScaleAtom,
 } from "../../../atoms/atoms";
 
 import fetchData from "../../../utils/axios";
 
-import Loading from "../../shared/Loading";
 import PortalFooter from "./PortalFooter";
 import PortalTable from "./PortalTable";
 import Button from "../../shared/Button";
@@ -31,49 +27,9 @@ function Portal({ index, relationship }) {
   );
 
   const currentDBId = useAtomValue(currentDBIdAtom);
-  const currentDocIndex = useAtomValue(currentDocIndexAtom);
-  const docData = useAtomValue(docDataAtom);
-  const primaryField = useAtomValue(primaryFieldAtom);
 
   const setDraggingElement = useSetAtom(draggingElementAtom);
   const setElementScale = useSetAtom(elementScaleAtom);
-
-  async function getForeignDocuments(relationshipsIndex) {
-    let queryValue = "";
-
-    docData[currentDocIndex]?.fields.forEach(element => {
-      if (primaryField[relationshipsIndex] === element.fieldName) {
-        queryValue = element.fieldValue.trim();
-      }
-    });
-
-    if (relationship._id) {
-      const response = await fetchData(
-        "GET",
-        `users/${userId}/databases/${currentDBId}/relationships/${relationship._id}?primaryFieldValue=${queryValue}`,
-      );
-
-      return response.data;
-    }
-
-    return [];
-  }
-
-  const { data: foreignDocuments, isLoading } = useQuery(
-    ["foreignDocuments1", currentDBId, currentDocIndex, relationship._id],
-    () => getForeignDocuments(index),
-    {
-      enabled:
-        !!userId &&
-        !!currentDBId &&
-        currentDocIndex !== undefined &&
-        !!relationshipsData,
-      refetchOnWindowFocus: false,
-      onFailure: () => {
-        console.log("sending user to errorpage");
-      },
-    },
-  );
 
   async function deleteRelationship(relationshipIndex) {
     await fetchData(
@@ -91,10 +47,6 @@ function Portal({ index, relationship }) {
       console.log("sending user to errorpage");
     },
   });
-
-  if (isLoading) {
-    return <Loading />;
-  }
 
   return (
     <div
@@ -122,11 +74,7 @@ function Portal({ index, relationship }) {
         style={{ height: `${relationship.portalSize}px` }}
         onDoubleClick={() => setIsEditMode(true)}
       >
-        <PortalTable
-          index={index}
-          relationship={relationship}
-          foreignDocuments={foreignDocuments.displayedDocuments}
-        />
+        <PortalTable index={index} relationship={relationship} />
         {isEditMode && (
           <Button
             className="absolute -top-3 -right-3 w-6 rounded-full"

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,15 +1,17 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import { useQuery } from "@tanstack/react-query";
 import { useContext } from "react";
+import { useAtomValue } from "jotai";
+
+import { currentDBIdAtom } from "../../../atoms/atoms";
+
+import UserContext from "../../../context/UserContext";
+import fetchData from "../../../utils/axios";
+
+import Loading from "../../shared/Loading";
 import PortalFooter from "./PortalFooter";
 import PortalTable from "./PortalTable";
 import Button from "../../shared/Button";
-
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
-import UserContext from "../../../context/UserContext";
-import Loading from "../../shared/Loading";
-
-import fetchData from "../../../utils/axios";
 
 function Portal({
   index,
@@ -27,7 +29,7 @@ function Portal({
   setElementScale,
 }) {
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getForeignDocuments(relationshipsIndex) {
     let queryValue = "";

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useContext } from "react";
 import { useAtomValue } from "jotai";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 import fetchData from "../../../utils/axios";
@@ -23,13 +23,13 @@ function Portal({
   setIsEditMode,
   handleClickDelete,
   docData,
-  currentDocIndex,
   primaryField,
   relationshipsData,
   setElementScale,
 }) {
   const { userId } = useContext(UserContext);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
 
   async function getForeignDocuments(relationshipsIndex) {
     let queryValue = "";

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -7,6 +7,7 @@ import {
   currentDBIdAtom,
   currentDocIndexAtom,
   isEditModeAtom,
+  relationshipsDataAtom,
 } from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
@@ -20,19 +21,19 @@ import Button from "../../shared/Button";
 function Portal({
   index,
   relationship,
-  setRelationshipsData,
   draggingElement,
   setDraggingElement,
   handleClickDelete,
   docData,
   primaryField,
-  relationshipsData,
   setElementScale,
 }) {
   const { userId } = useContext(UserContext);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   async function getForeignDocuments(relationshipsIndex) {
     let queryValue = "";
@@ -117,13 +118,7 @@ function Portal({
         )}
       </div>
       <div className="hidden group-hover:flex hover:flex">
-        {isEditMode && (
-          <PortalFooter
-            relationshipsData={relationshipsData}
-            setRelationshipsData={setRelationshipsData}
-            index={index}
-          />
-        )}
+        {isEditMode && <PortalFooter index={index} />}
       </div>
     </div>
   );

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,9 +1,13 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import { useQuery } from "@tanstack/react-query";
 import { useContext } from "react";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
-import { currentDBIdAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  currentDocIndexAtom,
+  isEditModeAtom,
+} from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 import fetchData from "../../../utils/axios";
@@ -19,8 +23,6 @@ function Portal({
   setRelationshipsData,
   draggingElement,
   setDraggingElement,
-  isEditMode,
-  setIsEditMode,
   handleClickDelete,
   docData,
   primaryField,
@@ -28,6 +30,7 @@ function Portal({
   setElementScale,
 }) {
   const { userId } = useContext(UserContext);
+  const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
 
@@ -100,7 +103,6 @@ function Portal({
       >
         <PortalTable
           index={index}
-          isEditMode={isEditMode}
           draggingElement={draggingElement}
           relationship={relationship}
           foreignDocuments={foreignDocuments.displayedDocuments}

--- a/src/components/contents/DetailViewItems/PortalFooter.jsx
+++ b/src/components/contents/DetailViewItems/PortalFooter.jsx
@@ -1,6 +1,14 @@
+import { useAtom } from "jotai";
+
+import { relationshipsDataAtom } from "../../../atoms/atoms";
+
 import Button from "../../shared/Button";
 
-function PortalFooter({ relationshipsData, setRelationshipsData, index }) {
+function PortalFooter({ index }) {
+  const [relationshipsData, setRelationshipsData] = useAtom(
+    relationshipsDataAtom,
+  );
+
   function handleClickSize(size) {
     const newRelationshipData = [...relationshipsData];
 

--- a/src/components/contents/DetailViewItems/PortalTable.jsx
+++ b/src/components/contents/DetailViewItems/PortalTable.jsx
@@ -41,7 +41,7 @@ function PortalTable({ index, relationship }) {
         `users/${userId}/databases/${currentDBId}/relationships/${relationship._id}?primaryFieldValue=${queryValue}`,
       );
 
-      return response.data.foreignDocuments;
+      return response.data.displayedDocuments;
     }
 
     return [];

--- a/src/components/contents/DetailViewItems/PortalTable.jsx
+++ b/src/components/contents/DetailViewItems/PortalTable.jsx
@@ -1,9 +1,10 @@
 import { useAtomValue } from "jotai";
 
-import { isEditModeAtom } from "../../../atoms/atoms";
+import { isEditModeAtom, draggingElementAtom } from "../../../atoms/atoms";
 
-function PortalTable({ draggingElement, relationship, foreignDocuments }) {
+function PortalTable({ relationship, foreignDocuments }) {
   const isEditMode = useAtomValue(isEditModeAtom);
+  const draggingElement = useAtomValue(draggingElementAtom);
 
   if (!foreignDocuments || foreignDocuments.length === 0) {
     return null;

--- a/src/components/contents/DetailViewItems/PortalTable.jsx
+++ b/src/components/contents/DetailViewItems/PortalTable.jsx
@@ -1,9 +1,10 @@
-function PortalTable({
-  isEditMode,
-  draggingElement,
-  relationship,
-  foreignDocuments,
-}) {
+import { useAtomValue } from "jotai";
+
+import { isEditModeAtom } from "../../../atoms/atoms";
+
+function PortalTable({ draggingElement, relationship, foreignDocuments }) {
+  const isEditMode = useAtomValue(isEditModeAtom);
+
   if (!foreignDocuments || foreignDocuments.length === 0) {
     return null;
   }

--- a/src/components/contents/DetailViewItems/PortalTable.jsx
+++ b/src/components/contents/DetailViewItems/PortalTable.jsx
@@ -1,10 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
+import fetchData from "../../../utils/axios";
 
-import { isEditModeAtom, draggingElementAtom } from "../../../atoms/atoms";
+import {
+  isEditModeAtom,
+  draggingElementAtom,
+  currentDocIndexAtom,
+  docDataAtom,
+  primaryFieldAtom,
+  userAtom,
+  currentDBIdAtom,
+  relationshipsDataAtom,
+} from "../../../atoms/atoms";
 
-function PortalTable({ relationship, foreignDocuments }) {
+import Loading from "../../shared/Loading";
+
+function PortalTable({ index, relationship }) {
+  const { userId } = useAtomValue(userAtom);
+  const currentDBId = useAtomValue(currentDBIdAtom);
+
   const isEditMode = useAtomValue(isEditModeAtom);
   const draggingElement = useAtomValue(draggingElementAtom);
+  const currentDocIndex = useAtomValue(currentDocIndexAtom);
+  const docData = useAtomValue(docDataAtom);
+  const primaryField = useAtomValue(primaryFieldAtom);
+  const relationshipsData = useAtomValue(relationshipsDataAtom);
+
+  async function getForeignDocuments(relationshipsIndex) {
+    let queryValue = "";
+
+    docData[currentDocIndex]?.fields.forEach(element => {
+      if (primaryField[relationshipsIndex] === element.fieldName) {
+        queryValue = element.fieldValue.trim();
+      }
+    });
+
+    if (relationship._id) {
+      const response = await fetchData(
+        "GET",
+        `users/${userId}/databases/${currentDBId}/relationships/${relationship._id}?primaryFieldValue=${queryValue}`,
+      );
+
+      return response.data.foreignDocuments;
+    }
+
+    return [];
+  }
+
+  const { data: foreignDocuments, isLoading } = useQuery(
+    ["foreignDocuments1", currentDBId, currentDocIndex, relationship._id],
+    () => getForeignDocuments(index),
+    {
+      enabled:
+        !!userId &&
+        !!currentDBId &&
+        currentDocIndex !== undefined &&
+        !!relationshipsData,
+      refetchOnWindowFocus: false,
+      onFailure: () => {
+        console.log("sending user to errorpage");
+      },
+    },
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   if (!foreignDocuments || foreignDocuments.length === 0) {
     return null;
@@ -47,10 +108,10 @@ function PortalTable({ relationship, foreignDocuments }) {
             })}
           </tr>
         ) : (
-          foreignDocuments.map((element, index) => {
+          foreignDocuments.map((element, fieldIndex) => {
             return (
               <tr
-                key={element.fields[index]._id}
+                key={element.fields[fieldIndex]._id}
                 className="w-[130px] h-10 border border-dark-grey text-center"
               >
                 {element.fields.map(field => {

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -1,12 +1,12 @@
 import { useState, useContext } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useAtomValue } from "jotai";
-import PropTypes from "prop-types";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import {
   currentDBIdAtom,
   isEditModeAtom,
   isOnSaveAtom,
+  documentsIdsAtom,
 } from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
@@ -18,15 +18,19 @@ import TableHead from "./TableHead";
 import TableBody from "./TableBody";
 import Loading from "../../shared/Loading";
 
-function ListView({ setDocumentsIds }) {
+function ListView() {
   const queryClient = useQueryClient();
 
   const [changedDoc, setChangedDoc] = useState([]);
 
   const { userId } = useContext(UserContext);
+
   const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
+
   const currentDBId = useAtomValue(currentDBIdAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
+
+  const setDocumentsIds = useSetAtom(documentsIdsAtom);
 
   async function getDocumentsList() {
     const response = await fetchData(
@@ -106,9 +110,5 @@ function ListView({ setDocumentsIds }) {
     </div>
   );
 }
-
-ListView.propTypes = {
-  setDocumentsIds: PropTypes.func.isRequired,
-};
 
 export default ListView;

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -1,9 +1,13 @@
 import { useState, useContext } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
-import { currentDBIdAtom, isEditModeAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  isEditModeAtom,
+  isOnSaveAtom,
+} from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 
@@ -14,12 +18,13 @@ import TableHead from "./TableHead";
 import TableBody from "./TableBody";
 import Loading from "../../shared/Loading";
 
-function ListView({ setDocumentsIds, isOnSave, setIsOnSave }) {
+function ListView({ setDocumentsIds }) {
   const queryClient = useQueryClient();
 
   const [changedDoc, setChangedDoc] = useState([]);
 
   const { userId } = useContext(UserContext);
+  const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
@@ -96,7 +101,6 @@ function ListView({ setDocumentsIds, isOnSave, setIsOnSave }) {
           documents={data.documents}
           changedDoc={changedDoc}
           setChangedDoc={setChangedDoc}
-          setIsOnSave={setIsOnSave}
         />
       </table>
     </div>

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -1,8 +1,11 @@
 import { useState, useContext } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
+
+import { currentDBIdAtom } from "../../../atoms/atoms";
+
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 import fetchData from "../../../utils/axios";
 import useLoading from "../../../utils/useLoading";
@@ -22,7 +25,7 @@ function ListView({
 }) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [changedDoc, setChangedDoc] = useState([]);
 

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
@@ -7,9 +7,8 @@ import {
   isEditModeAtom,
   isOnSaveAtom,
   documentsIdsAtom,
+  userAtom,
 } from "../../../atoms/atoms";
-
-import UserContext from "../../../context/UserContext";
 
 import fetchData from "../../../utils/axios";
 import useLoading from "../../../utils/useLoading";
@@ -23,10 +22,9 @@ function ListView() {
 
   const [changedDoc, setChangedDoc] = useState([]);
 
-  const { userId } = useContext(UserContext);
-
   const [isOnSave, setIsOnSave] = useAtom(isOnSaveAtom);
 
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -17,8 +17,6 @@ import Loading from "../../shared/Loading";
 function ListView({
   isEditMode,
   setIsEditMode,
-  currentDocIndex,
-  setCurrentDocIndex,
   setDocumentsIds,
   isOnSave,
   setIsOnSave,
@@ -100,8 +98,6 @@ function ListView({
         <TableHead fields={data.documents[0].fields} />
         <TableBody
           documents={data.documents}
-          currentDocIndex={currentDocIndex}
-          setCurrentDocIndex={setCurrentDocIndex}
           changedDoc={changedDoc}
           setChangedDoc={setChangedDoc}
           setIsOnSave={setIsOnSave}
@@ -116,7 +112,6 @@ function ListView({
 ListView.propTypes = {
   isEditMode: PropTypes.bool.isRequired,
   setIsEditMode: PropTypes.func.isRequired,
-  currentDocIndex: PropTypes.number.isRequired,
   setDocumentsIds: PropTypes.func.isRequired,
 };
 

--- a/src/components/contents/ListViewItems/ListView.jsx
+++ b/src/components/contents/ListViewItems/ListView.jsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 import PropTypes from "prop-types";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
+import { currentDBIdAtom, isEditModeAtom } from "../../../atoms/atoms";
 
 import UserContext from "../../../context/UserContext";
 
@@ -14,18 +14,14 @@ import TableHead from "./TableHead";
 import TableBody from "./TableBody";
 import Loading from "../../shared/Loading";
 
-function ListView({
-  isEditMode,
-  setIsEditMode,
-  setDocumentsIds,
-  isOnSave,
-  setIsOnSave,
-}) {
+function ListView({ setDocumentsIds, isOnSave, setIsOnSave }) {
   const queryClient = useQueryClient();
-  const { userId } = useContext(UserContext);
-  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [changedDoc, setChangedDoc] = useState([]);
+
+  const { userId } = useContext(UserContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
+  const isEditMode = useAtomValue(isEditModeAtom);
 
   async function getDocumentsList() {
     const response = await fetchData(
@@ -101,8 +97,6 @@ function ListView({
           changedDoc={changedDoc}
           setChangedDoc={setChangedDoc}
           setIsOnSave={setIsOnSave}
-          setIsEditMode={setIsEditMode}
-          isEditMode={isEditMode}
         />
       </table>
     </div>
@@ -110,8 +104,6 @@ function ListView({
 }
 
 ListView.propTypes = {
-  isEditMode: PropTypes.bool.isRequired,
-  setIsEditMode: PropTypes.func.isRequired,
   setDocumentsIds: PropTypes.func.isRequired,
 };
 

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -7,11 +7,13 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   isOnSaveAtom,
+  changedDocAtom,
 } from "../../../atoms/atoms";
 
-function TableBody({ documents, changedDoc, setChangedDoc }) {
+function TableBody({ documents }) {
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+  const [changedDoc, setChangedDoc] = useAtom(changedDocAtom);
   const setIsOnSave = useSetAtom(isOnSaveAtom);
 
   function adjustTextareaHeight(event) {

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -1,13 +1,18 @@
 import { useEffect } from "react";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 
 import getTodaysDate from "../../../utils/getTodaysDate";
 
-import { currentDocIndexAtom, isEditModeAtom } from "../../../atoms/atoms";
+import {
+  currentDocIndexAtom,
+  isEditModeAtom,
+  isOnSaveAtom,
+} from "../../../atoms/atoms";
 
-function TableBody({ documents, changedDoc, setChangedDoc, setIsOnSave }) {
+function TableBody({ documents, changedDoc, setChangedDoc }) {
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
+  const setIsOnSave = useSetAtom(isOnSaveAtom);
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -3,17 +3,11 @@ import { useAtom } from "jotai";
 
 import getTodaysDate from "../../../utils/getTodaysDate";
 
-import { currentDocIndexAtom } from "../../../atoms/atoms";
+import { currentDocIndexAtom, isEditModeAtom } from "../../../atoms/atoms";
 
-function TableBody({
-  documents,
-  changedDoc,
-  setChangedDoc,
-  setIsOnSave,
-  setIsEditMode,
-  isEditMode,
-}) {
+function TableBody({ documents, changedDoc, setChangedDoc, setIsOnSave }) {
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
+  const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -1,16 +1,20 @@
 import { useEffect } from "react";
+import { useAtom } from "jotai";
+
 import getTodaysDate from "../../../utils/getTodaysDate";
+
+import { currentDocIndexAtom } from "../../../atoms/atoms";
 
 function TableBody({
   documents,
-  currentDocIndex,
-  setCurrentDocIndex,
   changedDoc,
   setChangedDoc,
   setIsOnSave,
   setIsEditMode,
   isEditMode,
 }) {
+  const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
+
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;
   }

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -1,12 +1,11 @@
 import { useEffect } from "react";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 
 import getTodaysDate from "../../../utils/getTodaysDate";
 
 import {
   currentDocIndexAtom,
   isEditModeAtom,
-  isOnSaveAtom,
   changedDocAtom,
 } from "../../../atoms/atoms";
 
@@ -14,7 +13,6 @@ function TableBody({ documents }) {
   const [currentDocIndex, setCurrentDocIndex] = useAtom(currentDocIndexAtom);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const [changedDoc, setChangedDoc] = useAtom(changedDocAtom);
-  const setIsOnSave = useSetAtom(isOnSaveAtom);
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;
@@ -96,7 +94,6 @@ function TableBody({ documents }) {
               key={field._id}
               id={field.field}
               onDoubleClick={() => {
-                setIsOnSave(true);
                 setIsEditMode(true);
               }}
               className="h-full border"

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import PropTypes from "prop-types";
 
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateNewDatabase/CreateDBModal";
 
-function NoDatabase({ setCurrentDBId, setCurrentDBName }) {
+function NoDatabase({ setCurrentDBName }) {
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return (
@@ -25,16 +24,11 @@ function NoDatabase({ setCurrentDBId, setCurrentDBName }) {
       {showCreateDBModal && (
         <CreateDBModal
           closeModal={() => setShowCreateDBModal(false)}
-          setCurrentDBId={setCurrentDBId}
           setCurrentDBName={setCurrentDBName}
         />
       )}
     </div>
   );
 }
-
-NoDatabase.propTypes = {
-  setCurrentDBId: PropTypes.func.isRequired,
-};
 
 export default NoDatabase;

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -4,12 +4,7 @@ import PropTypes from "prop-types";
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateNewDatabase/CreateDBModal";
 
-function NoDatabase({
-  isListView,
-  setIsListView,
-  setCurrentDBId,
-  setCurrentDBName,
-}) {
+function NoDatabase({ setCurrentDBId, setCurrentDBName }) {
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return (
@@ -32,8 +27,6 @@ function NoDatabase({
           closeModal={() => setShowCreateDBModal(false)}
           setCurrentDBId={setCurrentDBId}
           setCurrentDBName={setCurrentDBName}
-          isListView={isListView}
-          setIsListView={setIsListView}
         />
       )}
     </div>

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -1,10 +1,14 @@
-import { useState } from "react";
+import { useAtom } from "jotai";
+
+import { showCreateDBModalAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateNewDatabase/CreateDBModal";
 
 function NoDatabase() {
-  const [showCreateDBModal, setShowCreateDBModal] = useState(false);
+  const [showCreateDBModal, setShowCreateDBModal] = useAtom(
+    showCreateDBModalAtom,
+  );
 
   return (
     <div className="flex flex-col justify-center">
@@ -21,9 +25,7 @@ function NoDatabase() {
           Click here to get Started!
         </Button>
       </div>
-      {showCreateDBModal && (
-        <CreateDBModal closeModal={() => setShowCreateDBModal(false)} />
-      )}
+      {showCreateDBModal && <CreateDBModal />}
     </div>
   );
 }

--- a/src/components/contents/NoDatabase.jsx
+++ b/src/components/contents/NoDatabase.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import Button from "../shared/Button";
 import CreateDBModal from "../Modals/CreateNewDatabase/CreateDBModal";
 
-function NoDatabase({ setCurrentDBName }) {
+function NoDatabase() {
   const [showCreateDBModal, setShowCreateDBModal] = useState(false);
 
   return (
@@ -22,10 +22,7 @@ function NoDatabase({ setCurrentDBName }) {
         </Button>
       </div>
       {showCreateDBModal && (
-        <CreateDBModal
-          closeModal={() => setShowCreateDBModal(false)}
-          setCurrentDBName={setCurrentDBName}
-        />
+        <CreateDBModal closeModal={() => setShowCreateDBModal(false)} />
       )}
     </div>
   );

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -4,26 +4,24 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  relationshipsAtom,
+  userAtom,
+} from "../../../atoms/atoms";
 
 import Button from "../../shared/Button";
 
-function DatabaseFields({
-  fields,
-  databaseName,
-  primaryDbId,
-  databaseId,
-  dbIndex,
-  relationships,
-}) {
+function DatabaseFields({ fields, databaseName, databaseId, dbIndex }) {
   const queryClient = useQueryClient();
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
+  const relationships = useAtomValue(relationshipsAtom);
 
   const [fieldNames, setFieldNames] = useState([]);
   const [relationId, setRelationId] = useState("");
   const [updatedFields, setUpdatedFields] = useState(() => {
-    if (primaryDbId === databaseId) {
+    if (currentDBId === databaseId) {
       const primaryFieldNames = relationships.map(
         relation => relation.primaryFieldName,
       );
@@ -87,19 +85,19 @@ function DatabaseFields({
   return (
     <div
       className={`relative group flex flex-col justify-center items-center w-64 mb-20
-      ${primaryDbId === databaseId ? "rounded-md p-1" : ""}
-      ${primaryDbId === databaseId ? "ring-4 ring-blue" : ""}
-      ${primaryDbId !== databaseId ? "hover:rounded-md p-1" : ""}
-      ${primaryDbId !== databaseId ? "hover:ring-4 ring-red" : ""}
+      ${currentDBId === databaseId ? "rounded-md p-1" : ""}
+      ${currentDBId === databaseId ? "ring-4 ring-blue" : ""}
+      ${currentDBId !== databaseId ? "hover:rounded-md p-1" : ""}
+      ${currentDBId !== databaseId ? "hover:ring-4 ring-red" : ""}
       }
-      ${databaseId !== primaryDbId && dbIndex === 0 ? "mt-8" : ""}`}
+      ${databaseId !== currentDBId && dbIndex === 0 ? "mt-8" : ""}`}
     >
       <div className="flex flex-col w-full mb-2 border-2 rounded-md items-center bg-blue bg-opacity-50">
         <span className="flex font-bold py-1">{databaseName}</span>
       </div>
       <Button
         className={`absolute -top-3 -right-3 flex w-6 h-6 hidden ${
-          primaryDbId !== databaseId ? "group-hover:block" : ""
+          currentDBId !== databaseId ? "group-hover:block" : ""
         }`}
         onClick={fetchDeleteRelationship}
       >

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable no-else-return */
 import { useState, useContext } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import Button from "../../shared/Button";
 
 function DatabaseFields({
@@ -18,7 +19,7 @@ function DatabaseFields({
 }) {
   const queryClient = useQueryClient();
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [fieldNames, setFieldNames] = useState([]);
   const [relationId, setRelationId] = useState("");

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable no-else-return */
-import { useState, useContext } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
 
-import UserContext from "../../../context/UserContext";
-import { currentDBIdAtom } from "../../../atoms/atoms";
 import Button from "../../shared/Button";
 
 function DatabaseFields({
@@ -18,7 +17,7 @@ function DatabaseFields({
   relationships,
 }) {
   const queryClient = useQueryClient();
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   const [fieldNames, setFieldNames] = useState([]);

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -1,10 +1,15 @@
 import { useState, useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
+import {
+  currentDBIdAtom,
+  relationshipsAtom,
+  showRelationshipModalAtom,
+  userAtom,
+} from "../../../atoms/atoms";
 
 import DatabaseFields from "./DatabaseFields";
 import Button from "../../shared/Button";
@@ -12,9 +17,12 @@ import RelationshipModal from "../../Modals/Relationship/RelationshipModal";
 import Loading from "../../shared/Loading";
 
 function Relationship() {
-  const [showRelationshipModal, setShowRelationshipModal] = useState(false);
   const [docs, setDocs] = useState([]);
-  const [relationships, setRelationships] = useState([]);
+
+  const setRelationships = useSetAtom(relationshipsAtom);
+  const [showRelationshipModal, setShowRelationshipModal] = useAtom(
+    showRelationshipModalAtom,
+  );
 
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
@@ -98,10 +106,8 @@ function Relationship() {
               key={crypto.randomUUID()}
               fields={database.documents[0].fields}
               databaseName={database.name}
-              primaryDbId={currentDBId}
               databaseId={database._id}
               dbIndex={index}
-              relationships={relationships}
             />
             {docs.length === 2 && index === 0 && (
               <div className="border border-dashed w-80 h-0 mt-16 border-blue"></div>
@@ -133,10 +139,7 @@ function Relationship() {
           </Button>
         )}
         {showRelationshipModal && (
-          <RelationshipModal
-            closeModal={() => setShowRelationshipModal(false)}
-            databaseName={documentQuery.data.name}
-          />
+          <RelationshipModal databaseName={documentQuery.data.name} />
         )}
       </div>
     </div>

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -1,10 +1,11 @@
 import { useContext, useState, useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
+import { currentDBIdAtom } from "../../../atoms/atoms";
 import UserContext from "../../../context/UserContext";
-import CurrentDBIdContext from "../../../context/CurrentDBIdContext";
 
 import DatabaseFields from "./DatabaseFields";
 import Button from "../../shared/Button";
@@ -17,7 +18,7 @@ function Relationship() {
   const [relationships, setRelationships] = useState([]);
 
   const { userId } = useContext(UserContext);
-  const currentDBId = useContext(CurrentDBIdContext);
+  const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDocumentsList() {
     const response = await fetchData(

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -1,11 +1,10 @@
-import { useContext, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { useAtomValue } from "jotai";
 
 import fetchData from "../../../utils/axios";
 
-import { currentDBIdAtom } from "../../../atoms/atoms";
-import UserContext from "../../../context/UserContext";
+import { currentDBIdAtom, userAtom } from "../../../atoms/atoms";
 
 import DatabaseFields from "./DatabaseFields";
 import Button from "../../shared/Button";
@@ -17,7 +16,7 @@ function Relationship() {
   const [docs, setDocs] = useState([]);
   const [relationships, setRelationships] = useState([]);
 
-  const { userId } = useContext(UserContext);
+  const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   async function getDocumentsList() {

--- a/src/context/CurrentDBIdContext.jsx
+++ b/src/context/CurrentDBIdContext.jsx
@@ -1,5 +1,0 @@
-import { createContext } from "react";
-
-const CurrentDBIdContext = createContext("");
-
-export default CurrentDBIdContext;

--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -1,5 +1,0 @@
-import { createContext } from "react";
-
-const UserContext = createContext("");
-
-export default UserContext;


### PR DESCRIPTION
### client 상태관리 라이브러리 도입

### description

기존 Prop - drilling 방식으로 관리되던 client의 상태 관리 방식을 jotai 라이브러리를 도입해 변경 하였습니다. 
최초 방대하던 state의 양으로 인해 관리할 state들을 atoms.js 파일 한곳에 몰아넣는 방식으로 진행 하였는데, 
추후 가능하다면 관심사별 파일로 분리 및 Provider 컴포넌트를 활용해 각 state들의 scope를 제한하는 방향으로 진행하면 좋을듯 합니다.

- [Provider - jotai](https://jotai.org/docs/core/provider#provider)
- [atoms.js](https://github.com/Team-Dataface/DataFace-client/blob/156f8b15cef0ce369a92ac3efdbc7760ec0e629c/src/atoms/atoms.js)

### concern

기능에 있어서 중간 중간 오류가 발생하지 않도록 최대한 실 사용 테스트를 진행하였으나 제가 놓친 부분이 분명 있을 수 있으니 혹시 이후에 작업 진행하시다가 발견되는 부분이 있다면 말씀 부탁드려 봅니다! 

### remarks

- 기존 `Listview.jsx`와 `Detailview.jsx` 두가지 파일에서 각자 다르게 나뉘어져 있던 fetch 로직을 `SaveButton`컴포넌트로 통합 하였습니다. 

**기존**

`Listview.jsx`에서 저장하는 로직 -> `Listview.jsx`에서 담당
`Detailview.jsx` 저장하는 로직 -> `Detailview.jsx`에서 담당
state 바뀜 -> 리렌더 -> state 조건문에 의한 fetch가 이루어지는 방식

**변경**

`Listview.jsx`와 `Detailview.jsx` 저장하는 로직들 -> SaveButton 컴포넌트에서 일괄담당 
(isListView state에 따른 분기처리를 통해 다른 로직으로 서버에 fetch)

저장버튼 누름 -> isListView state에 따라 해당 분기에 맞는 로직으로 서버에 fetch
--> `Listview.jsx`와 `Detailview.jsx`의 데이터 양에 따라 전체 데이터를 fecth 하는 방식은 `Listview.jsx`에선 불필요하게 많은 data들이 서버에 fetch 되는 소요를 막고자 위와 같이 로직이 분리되어 있으니 참고 부탁드립니다.

### conflict 발생 시

1. 충돌 해결은 반드시 에디터에서 할 것.
2. add
3. rebase —continue
4. push (origin feature)

### 주의 사항

- push는 반드시 해당 feature 브랜치에 할 것
- conflict를 모두 해결하고 PR 올리기
- PR시 conflict 발생 시와 주의 사항은 지우고 올려주세요

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.
