### PR TITLE
Feat. add delete Rel and delete DB modal

### DIFF
--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -25,6 +25,10 @@ export const showCreateDBModalAtom = atom(false);
 export const showAddDocumentModalAtom = atom(false);
 export const showDeleteDocumentModalAtom = atom(false);
 export const showRelationshipModalAtom = atom(false);
+export const showDeleteDBModalAtom = atom(false);
+export const deleteTargetDBIdAtom = atom(null);
+export const showDeleteRelationshipModalAtom = atom(false);
+export const deleteTargetRelationshipAtom = atom(null);
 export const isLastDocumentAtom = atom(false);
 
 export const fieldsAtom = atom([]);

--- a/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
@@ -68,7 +68,7 @@ CreateDBInputList.propTypes = {
       fieldName: PropTypes.string.isRequired,
       fieldType: PropTypes.string.isRequired,
     }),
-  ).isRequired,
+  ),
   updateFieldName: PropTypes.func,
   updateFieldType: PropTypes.func,
   handleClickDeleteField: PropTypes.func,

--- a/src/components/Modals/DeleteDatabase/DeleteDBModal.jsx
+++ b/src/components/Modals/DeleteDatabase/DeleteDBModal.jsx
@@ -1,0 +1,93 @@
+import { useSetAtom, useAtomValue } from "jotai";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetchData from "../../../utils/axios";
+import {
+  currentDBIdAtom,
+  currentDBNameAtom,
+  userAtom,
+  currentDocIndexAtom,
+  showDeleteDBModalAtom,
+  deleteTargetDBIdAtom,
+} from "../../../atoms/atoms";
+
+import Modal from "../../shared/Modal";
+import Button from "../../shared/Button";
+import Content from "../SharedItems/Content";
+import ContentWrapper from "../SharedItems/ContentWrapper";
+import Message from "../SharedItems/Message";
+import Loading from "../../shared/Loading";
+
+function DeleteDBModal({ databases }) {
+  const queryClient = useQueryClient();
+
+  const { userId } = useAtomValue(userAtom);
+  const deleteTargetDBId = useAtomValue(deleteTargetDBIdAtom);
+
+  const setCurrentDBId = useSetAtom(currentDBIdAtom);
+  const setCurrentDBName = useSetAtom(currentDBNameAtom);
+  const setShowDeleteDBModal = useSetAtom(showDeleteDBModalAtom);
+  const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
+
+  async function deleteDatabase(databaseId) {
+    const response = await fetchData(
+      "DELETE",
+      `/users/${userId}/databases/${databaseId}`,
+    );
+
+    return response.data.databases;
+  }
+
+  const { mutate: fetchDeleteDB, isLoading } = useMutation(deleteDatabase, {
+    onSuccess: result => {
+      if (databases.length === 1) {
+        setCurrentDocIndex(0);
+        setCurrentDBName("");
+      } else {
+        setCurrentDBId(result[0]._id);
+        setCurrentDBName(result[0].name);
+      }
+
+      setShowDeleteDBModal(false);
+      queryClient.refetchQueries(["userDbList"]);
+    },
+    onFailure: () => {
+      console.log("sending user to errorpage");
+      setShowDeleteDBModal(false);
+    },
+  });
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <Modal onClick={() => setShowDeleteDBModal(false)}>
+      <ContentWrapper>
+        <Content>
+          <Message>
+            <span>
+              Are you sure you want to permanently delete this database?
+            </span>
+          </Message>
+        </Content>
+        <div className="flex justify-evenly items-center w-full">
+          <Button
+            className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
+            onClick={() => setShowDeleteDBModal(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="w-20 h-8 rounded-md bg-red text-white hover:bg-red-hover"
+            onClick={() => fetchDeleteDB(deleteTargetDBId)}
+          >
+            Delete
+          </Button>
+        </div>
+      </ContentWrapper>
+    </Modal>
+  );
+}
+
+export default DeleteDBModal;

--- a/src/components/Modals/DeleteRelationship/DeleteRelationshipModal.jsx
+++ b/src/components/Modals/DeleteRelationship/DeleteRelationshipModal.jsx
@@ -1,0 +1,85 @@
+import { useSetAtom, useAtomValue } from "jotai";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import fetchData from "../../../utils/axios";
+import {
+  currentDBIdAtom,
+  userAtom,
+  showDeleteRelationshipModalAtom,
+  deleteTargetRelationshipAtom,
+} from "../../../atoms/atoms";
+
+import Modal from "../../shared/Modal";
+import Button from "../../shared/Button";
+import Content from "../SharedItems/Content";
+import ContentWrapper from "../SharedItems/ContentWrapper";
+import Message from "../SharedItems/Message";
+import Loading from "../../shared/Loading";
+
+function DeleteRelationshipModal() {
+  const queryClient = useQueryClient();
+
+  const { userId } = useAtomValue(userAtom);
+  const currentDBId = useAtomValue(currentDBIdAtom);
+  const deleteTargetRelationship = useAtomValue(deleteTargetRelationshipAtom);
+
+  const setShowDeleteRelationshipModal = useSetAtom(
+    showDeleteRelationshipModalAtom,
+  );
+
+  async function deleteRelationship() {
+    await fetchData(
+      "DELETE",
+      `/users/${userId}/databases/${currentDBId}/relationships/${deleteTargetRelationship}`,
+    );
+  }
+
+  const { mutate: fetchDeleteRelationship, isLoading } = useMutation(
+    deleteRelationship,
+    {
+      onSuccess: () => {
+        queryClient.refetchQueries(["dbDocumentList", currentDBId]);
+        queryClient.refetchQueries(["dbRelationShips", currentDBId]);
+        setShowDeleteRelationshipModal(false);
+      },
+      onFailure: () => {
+        console.log("sending user to errorpage");
+      },
+    },
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <Modal onClick={() => setShowDeleteRelationshipModal(false)}>
+      <ContentWrapper>
+        <Content>
+          <Message>
+            <span>
+              Deleting this portal will also disconnect the associated
+              relationship. Are you sure you want to proceed?
+            </span>
+          </Message>
+        </Content>
+        <div className="flex justify-evenly items-center w-full">
+          <Button
+            className="w-20 h-8 rounded-md bg-black-bg text-white hover:bg-dark-grey"
+            onClick={() => setShowDeleteRelationshipModal(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="w-20 h-8 rounded-md bg-red text-white hover:bg-red-hover"
+            onClick={() => fetchDeleteRelationship()}
+          >
+            Delete
+          </Button>
+        </div>
+      </ContentWrapper>
+    </Modal>
+  );
+}
+
+export default DeleteRelationshipModal;

--- a/src/components/Modals/DeleteRelationship/DeleteRelationshipModal.jsx
+++ b/src/components/Modals/DeleteRelationship/DeleteRelationshipModal.jsx
@@ -58,8 +58,8 @@ function DeleteRelationshipModal() {
         <Content>
           <Message>
             <span>
-              Deleting this portal will also disconnect the associated
-              relationship. Are you sure you want to proceed?
+              Deleting this portal will also remove the existing relationships.
+              Are you sure you want to proceed?
             </span>
           </Message>
         </Content>

--- a/src/components/contents/DetailViewItems/Portal.jsx
+++ b/src/components/contents/DetailViewItems/Portal.jsx
@@ -1,52 +1,33 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAtom, useSetAtom, useAtomValue } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 
 import {
-  currentDBIdAtom,
   isEditModeAtom,
-  relationshipsDataAtom,
-  userAtom,
   draggingElementAtom,
   elementScaleAtom,
+  deleteTargetRelationshipAtom,
+  showDeleteRelationshipModalAtom,
 } from "../../../atoms/atoms";
-
-import fetchData from "../../../utils/axios";
 
 import PortalFooter from "./PortalFooter";
 import PortalTable from "./PortalTable";
 import Button from "../../shared/Button";
+import DeleteRelationshipModal from "../../Modals/DeleteRelationship/DeleteRelationshipModal";
 
 function Portal({ index, relationship }) {
-  const queryClient = useQueryClient();
-
-  const { userId } = useAtomValue(userAtom);
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
-  const [relationshipsData, setRelationshipsData] = useAtom(
-    relationshipsDataAtom,
+  const [showDeleteRelationshipModal, setShowDeleteRelationshipModal] = useAtom(
+    showDeleteRelationshipModalAtom,
   );
-
-  const currentDBId = useAtomValue(currentDBIdAtom);
 
   const setDraggingElement = useSetAtom(draggingElementAtom);
   const setElementScale = useSetAtom(elementScaleAtom);
+  const setDeleteTargetRelationship = useSetAtom(deleteTargetRelationshipAtom);
 
-  async function deleteRelationship(relationshipIndex) {
-    await fetchData(
-      "DELETE",
-      `/users/${userId}/databases/${currentDBId}/relationships/${relationshipsData[relationshipIndex]._id}`,
-    );
+  function handleClickDelete() {
+    setDeleteTargetRelationship(relationship._id);
+    setShowDeleteRelationshipModal(true);
   }
-
-  const { mutate: fetchDeleteRelationship } = useMutation(deleteRelationship, {
-    onSuccess: () => {
-      setRelationshipsData(null);
-      queryClient.refetchQueries(["dbDocumentList", currentDBId]);
-    },
-    onFailure: () => {
-      console.log("sending user to errorpage");
-    },
-  });
 
   return (
     <div
@@ -78,7 +59,7 @@ function Portal({ index, relationship }) {
         {isEditMode && (
           <Button
             className="absolute -top-3 -right-3 w-6 rounded-full"
-            onClick={() => fetchDeleteRelationship(index)}
+            onClick={() => handleClickDelete()}
           >
             <img src="/assets/close_icon.svg" alt="close button" />
           </Button>
@@ -87,6 +68,7 @@ function Portal({ index, relationship }) {
       <div className="hidden group-hover:flex hover:flex">
         {isEditMode && <PortalFooter index={index} />}
       </div>
+      {showDeleteRelationshipModal && <DeleteRelationshipModal />}
     </div>
   );
 }


### PR DESCRIPTION
### description

- 사이드바에서 휴지통버튼을 눌렀을 시 최종확인 모달 구현.
- 관계설정과 디테일뷰에서 각각 관계설정을 삭제할 시 최종확인 모달 구현.
이 과정에서 deleteRel 모달 내부의 하나의 삭제 fetch 함수를 보도록 정리하였습니다.

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷
![rel1](https://github.com/Team-Dataface/DataFace-client/assets/83858724/cad87680-d3bd-4753-b097-6d548cc1bbec)
![rel2](https://github.com/Team-Dataface/DataFace-client/assets/83858724/9ed1900b-bc79-4d5b-b8a8-fcbf16c09935)

