### PR TITLE
Test. modals for creating and deleting

### DIFF
--- a/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBInputList.jsx
@@ -39,6 +39,7 @@ function CreateDBInputList({ updateFieldName }) {
         <InputWrapper>
           <div className="flex flex-row justify-center items-center">
             <input
+              data-testid="field name"
               className="flex w-full h-7 mr-3 rounded-md text-center"
               maxLength={MAX_FIELD_NAME_LENGTH}
               value={element.name}

--- a/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
+++ b/src/components/Modals/CreateNewDatabase/CreateDBModal.jsx
@@ -104,11 +104,12 @@ function CreateDBModal() {
         <Content>
           <LabelArea>
             <Label>Database Name</Label>
-            <Label>Fields Name</Label>
+            <Label>Field Name</Label>
           </LabelArea>
           <InputsArea>
             <InputWrapper>
               <input
+                id="Database Name"
                 className="flex w-full h-7 rounded-lg text-center"
                 maxLength={CONSTANT.MAX_DATABASE_NAME_LENGTH}
                 onChange={event => handleOnDBNameChange(event)}

--- a/src/components/Modals/SharedItems/Label.jsx
+++ b/src/components/Modals/SharedItems/Label.jsx
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 function Label({ children }) {
   return (
     <div className="flex justify-end p-3">
-      <span className="flex items-center h-7 text-right">{children}</span>
+      <label htmlFor={children} className="flex items-center h-7 text-right">
+        {children}
+      </label>
     </div>
   );
 }

--- a/src/spec/components/Modals/AddNewDocument/AddDocModal.spec.jsx
+++ b/src/spec/components/Modals/AddNewDocument/AddDocModal.spec.jsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "jotai";
+import { showAddDocumentModalAtom } from '../../../../atoms/atoms';
+
+import AddDocModal from "../../../../components/Modals/AddNewDocument/AddDocModal"
+
+const queryClient = new QueryClient();
+
+const mocks = {
+  setShowAddDocumentModal: vi.fn(),
+};
+
+vi.mock("jotai", async () => {
+  const actualJotai = await vi.importActual("jotai");
+
+  return {
+    ...actualJotai,
+    useSetAtom: (atom) => {
+      if (atom === showAddDocumentModalAtom) {
+        return mocks.setShowAddDocumentModal;
+      }
+      return vi.fn();
+    },
+  };
+});
+
+describe("AddDocModal", () => {
+  beforeEach(() => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider>
+          <AddDocModal />
+        </Provider>
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title well", () => {
+    expect(screen.getByText("Add New Document")).toBeInTheDocument;
+  });
+
+  it("renders add button and submit button well", () => {
+    const closeButton = screen.getByAltText("close button");
+    const submitButton = screen.getByText("Submit");
+
+    expect(closeButton).toBeInTheDocument;
+    expect(submitButton).toBeInTheDocument;
+  });
+
+  it("closes the modal when close button is clicked", () => {
+    const closeButton = screen.getByAltText("close button");
+
+    fireEvent.click(closeButton);
+
+    expect(mocks.setShowAddDocumentModal).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/spec/components/Modals/CreateNewDatabase/CreateDBModal.spec.jsx
+++ b/src/spec/components/Modals/CreateNewDatabase/CreateDBModal.spec.jsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "jotai";
+import { showCreateDBModalAtom } from '../../../../atoms/atoms';
+
+import CreateDBModal from "../../../../components/Modals/CreateNewDatabase/CreateDBModal"
+
+const queryClient = new QueryClient();
+
+const mocks = {
+  setShowCreateDBModal: vi.fn(),
+  navigate: vi.fn(),
+};
+
+vi.mock("jotai", async () => {
+  const actualJotai = await vi.importActual("jotai");
+
+  return {
+    ...actualJotai,
+    useSetAtom: (atom) => {
+      if (atom === showCreateDBModalAtom) {
+        return mocks.setShowCreateDBModal;
+      }
+      return vi.fn();
+    },
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+describe("AddDocModal", () => {
+  beforeEach(() => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider>
+          <CreateDBModal />
+        </Provider>
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title well", () => {
+    expect(screen.getByText("Create New Database")).toBeInTheDocument;
+  });
+
+  it("renders add and submit buttons well", () => {
+    const closeButton = screen.getByAltText("close button");
+    const submitButton = screen.getByText("Submit");
+
+    expect(closeButton).toBeInTheDocument;
+    expect(submitButton).toBeInTheDocument;
+  });
+
+  it("renders input well", () => {
+    const dbNameInput = screen.getByLabelText("Database Name");
+
+    fireEvent.change(dbNameInput, { target: { value: "Test" } });
+
+    expect(dbNameInput.value).toBe("Test");
+  });
+
+  it("closes the modal when close button is clicked", () => {
+    const closeButton = screen.getByAltText("close button");
+
+    fireEvent.click(closeButton);
+
+    expect(mocks.setShowCreateDBModal).toHaveBeenCalledWith(false);
+  });
+
+  it("should add one more input when add button is clicked", async () => {
+    const addButton = screen.getByAltText("add button");
+
+    fireEvent.click(addButton);
+
+    const FieldNameInputs = screen.getAllByTestId("field name");
+    expect(FieldNameInputs.length).toBe(2);
+  });
+
+  it("should delete input when bin button is clicked", async () => {
+    const addButton = screen.getByAltText("add button");
+
+    fireEvent.click(addButton);
+
+    const binButton = screen.getAllByAltText("bin icon");
+
+    fireEvent.click(binButton[1]);
+
+    const FieldNameInputs = screen.getAllByTestId("field name");
+
+    expect(FieldNameInputs.length).toBe(1);
+  });
+
+  it("should not submit when database's name is empty", () => {
+    const submitButton = screen.getByText("Submit");
+
+    fireEvent.click(submitButton);
+
+    const warning = screen.getByText("Database's name cannot be empty.");
+
+    expect(warning).toBeInTheDocument;
+  });
+
+  it("should not submit when field's name is empty", async () => {
+    const dbNameInput = screen.getByLabelText("Database Name");
+
+    fireEvent.change(dbNameInput, { target: { value: "Test" } });
+
+    const submitButton = screen.getByText("Submit");
+
+    fireEvent.click(submitButton);
+
+    const warning = screen.getByText("Field's name cannot be empty.");
+
+    expect(warning).toBeInTheDocument;
+  });
+
+  it("should not submit when field's names are duplicated", async () => {
+    const dbNameInput = screen.getByLabelText("Database Name");
+
+    fireEvent.change(dbNameInput, { target: { value: "Test" } });
+
+    const addButton = screen.getByAltText("add button");
+
+    fireEvent.click(addButton);
+
+    const FieldNameInputs = screen.getAllByTestId("field name");
+
+    FieldNameInputs.forEach(input => {
+      fireEvent.change(input, { target: { value: "Test" } });
+    });
+
+    const submitButton = screen.getByText("Submit");
+
+    fireEvent.click(submitButton);
+
+    const warning = screen.getByText("Field's name cannot be same.");
+
+    expect(warning).toBeInTheDocument;
+  });
+});

--- a/src/spec/components/Modals/CreateNewDatabase/CreateDBModal.spec.jsx
+++ b/src/spec/components/Modals/CreateNewDatabase/CreateDBModal.spec.jsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Provider } from "jotai";
 import { showCreateDBModalAtom } from '../../../../atoms/atoms';
 
-import CreateDBModal from "../../../../components/Modals/CreateNewDatabase/CreateDBModal"
+import CreateDBModal from "../../../../components/Modals/CreateNewDatabase/CreateDBModal";
 
 const queryClient = new QueryClient();
 
@@ -44,7 +44,7 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-describe("AddDocModal", () => {
+describe("CreateDBModal", () => {
   beforeEach(() => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/src/spec/components/Modals/DeleteDatabase/DeleteDBModal.spec.jsx
+++ b/src/spec/components/Modals/DeleteDatabase/DeleteDBModal.spec.jsx
@@ -1,14 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Provider } from "jotai";
-import { showAddDocumentModalAtom } from '../../../../atoms/atoms';
+import { showDeleteDBModalAtom } from "../../../../atoms/atoms";
 
-import AddDocModal from "../../../../components/Modals/AddNewDocument/AddDocModal";
+import DeleteDBModal from "../../../../components/Modals/DeleteDatabase/DeleteDBModal";
 
 const queryClient = new QueryClient();
 
 const mocks = {
-  setShowAddDocumentModal: vi.fn(),
+  setShowDeleteDBModal: vi.fn(),
 };
 
 vi.mock("jotai", async () => {
@@ -17,20 +17,20 @@ vi.mock("jotai", async () => {
   return {
     ...actualJotai,
     useSetAtom: (atom) => {
-      if (atom === showAddDocumentModalAtom) {
-        return mocks.setShowAddDocumentModal;
+      if (atom === showDeleteDBModalAtom) {
+        return mocks.setShowDeleteDBModal;
       }
       return vi.fn();
     },
   };
 });
 
-describe("AddDocModal", () => {
+describe("DeleteDBModal", () => {
   beforeEach(() => {
     render(
       <QueryClientProvider client={queryClient}>
         <Provider>
-          <AddDocModal />
+          <DeleteDBModal />
         </Provider>
       </QueryClientProvider>
     );
@@ -41,15 +41,15 @@ describe("AddDocModal", () => {
   });
 
   it("renders title well", () => {
-    expect(screen.getByText("Add New Document")).toBeInTheDocument;
+    expect(screen.getByText("Are you sure you want to permanently delete this database?")).toBeInTheDocument;
   });
 
-  it("renders add button and submit button well", () => {
-    const closeButton = screen.getByAltText("close button");
-    const submitButton = screen.getByText("Submit");
+  it("closes the modal when cancel button is clicked", () => {
+    const cancelButton = screen.getByText("Cancel");
 
-    expect(closeButton).toBeInTheDocument;
-    expect(submitButton).toBeInTheDocument;
+    fireEvent.click(cancelButton);
+
+    expect(mocks.setShowDeleteDBModal).toHaveBeenCalledWith(false);
   });
 
   it("closes the modal when close button is clicked", () => {
@@ -57,6 +57,6 @@ describe("AddDocModal", () => {
 
     fireEvent.click(closeButton);
 
-    expect(mocks.setShowAddDocumentModal).toHaveBeenCalledWith(false);
+    expect(mocks.setShowDeleteDBModal).toHaveBeenCalledWith(false);
   });
 });

--- a/src/spec/components/Modals/DeleteDocument/DeleteDocModal.spec.jsx
+++ b/src/spec/components/Modals/DeleteDocument/DeleteDocModal.spec.jsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "jotai";
+import { showDeleteDocumentModalAtom, isLastDocumentAtom } from "../../../../atoms/atoms";
+
+import DeleteDocModal from "../../../../components/Modals/DeleteDocument/DeleteDocModal";
+
+const queryClient = new QueryClient();
+
+const mocks = {
+  setShowDeleteDocumentModal: vi.fn(),
+  setIsLastDocument: vi.fn(),
+  isLastDocument: false,
+};
+
+vi.mock("jotai", async () => {
+  const actualJotai = await vi.importActual("jotai");
+
+  return {
+    ...actualJotai,
+    useSetAtom: (atom) => {
+      if (atom === showDeleteDocumentModalAtom) {
+        return mocks.setShowDeleteDocumentModal;
+      }
+      return vi.fn();
+    },
+    useAtom: (atom) => {
+      if (atom === isLastDocumentAtom) {
+        return [mocks.isLastDocument, mocks.setIsLastDocument];
+      }
+      return [];
+    },
+  };
+});
+
+describe("DeleteDocModal in normal pattern", () => {
+  beforeEach(() => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider>
+          <DeleteDocModal />
+        </Provider>
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders delete confirmation message", () => {
+    expect(screen.getByText("Are you sure you want to permanently delete this document?")).toBeInTheDocument;
+  });
+
+  it("renders delete button well", () => {
+    const deleteButton = screen.getByText("Delete");
+    expect(deleteButton).toBeInTheDocument;
+  });
+
+  it("closes the modal when cancel button is clicked", () => {
+    const cancelButton = screen.getByText("Cancel");
+
+    fireEvent.click(cancelButton);
+
+    expect(mocks.setShowDeleteDocumentModal).toHaveBeenCalledWith(false);
+  });
+
+  it("closes the modal when close button is clicked", () => {
+    const closeButton = screen.getByAltText("close button");
+
+    fireEvent.click(closeButton);
+
+    expect(mocks.setShowDeleteDocumentModal).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("DeleteDocModal in edge case", () => {
+  beforeEach(() => {
+    mocks.isLastDocument = true;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider>
+          <DeleteDocModal />
+        </Provider>
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders warning well", () => {
+    expect(screen.getByText("Please ensure that the database contains at least one document before proceeding")).toBeInTheDocument;
+  });
+
+  it("renders cancel button well", () => {
+    const cancelButton = screen.getByText("Cancel");
+    expect(cancelButton).toBeInTheDocument;
+  });
+});
+

--- a/src/spec/components/Modals/DeleteRelationship/DeleteRelationshipModal.spec.jsx
+++ b/src/spec/components/Modals/DeleteRelationship/DeleteRelationshipModal.spec.jsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "jotai";
+import { showDeleteRelationshipModalAtom } from "../../../../atoms/atoms";
+
+import DeleteRelationshipModal from "../../../../components/Modals/DeleteRelationship/DeleteRelationshipModal";
+
+const queryClient = new QueryClient();
+
+const mocks = {
+  setShowDeleteRelationshipModal: vi.fn(),
+};
+
+vi.mock("jotai", async () => {
+  const actualJotai = await vi.importActual("jotai");
+
+  return {
+    ...actualJotai,
+    useSetAtom: (atom) => {
+      if (atom === showDeleteRelationshipModalAtom) {
+        return mocks.setShowDeleteRelationshipModal;
+      }
+      return vi.fn();
+    },
+  };
+});
+
+describe("DeleteRelationshipModal", () => {
+  beforeEach(() => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider>
+          <DeleteRelationshipModal />
+        </Provider>
+      </QueryClientProvider>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title well", () => {
+    const title = screen.getByText("Deleting this portal will also remove the existing relationships. Are you sure you want to proceed?");
+    expect(title).toBeInTheDocument;
+  });
+
+  it("closes the modal when cancel button is clicked", () => {
+    const cancelButton = screen.getByText("Cancel");
+
+    fireEvent.click(cancelButton);
+
+    expect(mocks.setShowDeleteRelationshipModal).toHaveBeenCalledWith(false);
+  });
+
+  it("closes the modal when close button is clicked", () => {
+    const closeButton = screen.getByAltText("close button");
+
+    fireEvent.click(closeButton);
+
+    expect(mocks.setShowDeleteRelationshipModal).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
### description

- api 요청을 제외한 부분을 테스트하였습니다.
- 커스텀훅 PR이 머지되고나면 rebase후 약간의 브러시업이 필요한 것이 예상됩니다.
(테스트 수행을 위해 각 컴포넌트에 queryClient를 적용중이나, 커스텀훅 쪽 브렌치에서는 제거되어있기 때문)

### conflict 발생 시

1. 충돌 해결은 반드시 에디터에서 할 것.
2. add
3. rebase —continue
4. push (origin feature)

### 주의 사항

- push는 반드시 해당 feature 브랜치에 할 것
- conflict를 모두 해결하고 PR 올리기
- PR시 conflict 발생 시와 주의 사항은 지우고 올려주세요

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷 (필요시)
<img width="881" alt="スクリーンショット 2023-11-24 2 29 41" src="https://github.com/Team-Dataface/DataFace-client/assets/83858724/66683c71-3ab4-40ba-9767-6b38ea1dd2b8">
<img width="878" alt="スクリーンショット 2023-11-24 2 26 37" src="https://github.com/Team-Dataface/DataFace-client/assets/83858724/d656a511-f6f5-453f-b2dd-28647d570875">
