### PR TITLE
Fix. replace disabled with pointerEvents

### DIFF
--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -104,7 +104,7 @@ function FieldList() {
               onDoubleClick={() => setIsEditMode(true)}
               onChange={event => updateFieldValue(index, event)}
               value={element.fieldValue}
-              disabled={
+              readOnly={
                 element.fieldType === "Date modified" ||
                 element.fieldType === "Date created" ||
                 !isEditMode

--- a/src/components/contents/ListViewItems/TableBody.jsx
+++ b/src/components/contents/ListViewItems/TableBody.jsx
@@ -109,7 +109,7 @@ function TableBody({ documents }) {
                     id={field._id}
                     rows="1"
                     defaultValue={field.fieldValue}
-                    disabled={!isEditMode}
+                    style={{ pointerEvents: isEditMode ? "auto" : "none" }}
                     onChange={event => handleOnChange(event, document._id)}
                   />
                 ) : (
@@ -122,11 +122,14 @@ function TableBody({ documents }) {
                     id={field._id}
                     type={field.fieldType}
                     defaultValue={field.fieldValue}
-                    disabled={
-                      field.fieldType === "Date modified" ||
-                      field.fieldType === "Date created" ||
-                      !isEditMode
-                    }
+                    style={{
+                      pointerEvents:
+                        field.fieldType === "Date modified" ||
+                        field.fieldType === "Date created" ||
+                        !isEditMode
+                          ? "none"
+                          : "auto",
+                    }}
                     onChange={event => handleOnChange(event, document._id)}
                   />
                 )}


### PR DESCRIPTION
### description

- Disabled속성을 가진 엘레멘트는 mouse event를 fire하지 않는 관계로 input을 클릭했을 때 document switch가 안되는 현상이 발견되었습니다.
-  disabled를 pointerEvents로 교체함으로써 input 엘레멘트의 click, :hover 등을 방지하여 우리가 원했던 비활성화 효과를 적용하는 동시에, input이 아닌, 부모가 가진 onClick은 이벤트 버블링을 통해 잘 작동하도록 했습니다.

### 주의 사항

- push는 반드시 해당 feature 브랜치에 할 것
- conflict를 모두 해결하고 PR 올리기
- PR시 conflict 발생 시와 주의 사항은 지우고 올려주세요

### PR 전 확인사항

- [X] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.

### 스크린샷

전
![before](https://github.com/Team-Dataface/DataFace-client/assets/83858724/4ef0103d-0a05-4644-85fa-9760296ffa45)

후
![after](https://github.com/Team-Dataface/DataFace-client/assets/83858724/9713c3fd-8d38-48bf-9cb1-c4a20a3ef455)

