### PR TITLE
Refactor. remove unnecessary atoms and enlarge the amount of direct usage of server states

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # **🔗 Links**
 
-<p align="center" style="display: flex; justify-content: space-evenly;">
+<p align="center">
   <a href="https://app.dataface.solutions">Deployed website</a>
   <span> | </span>
   <a href="https://github.com/Team-Dataface/DataFace-client">Frontend Repository</a>
@@ -22,23 +22,23 @@
 </p>
 
 # 📖 CONTENTS <!-- omit in toc -->
-- [**💪 Motivation**](#💪-motivation)
-- [**🛠 Tech Stacks**](#🛠-tech-stacks)
-  - [🤔 Why Tanstack-Query?](#🤔-why-tanstack-query)
-  - [🤔 Why MongoDB?](#🤔-why-mongodb)
-- [**🕹️ Features**](#🕹️-features)
-- [**🏔 Challenges**](#🏔-challenges)
-  - [1. MongoDB로 데이터베이스 간 관계 설정 기능을 어떻게 구현할까?](#1-1-관계형-db의-primary-key-foreign-key-개념을-응용)
+- [**💪 Motivation**](#-motivation)
+- [**🛠 Tech Stacks**](#-tech-stacks)
+  - [🤔 Why Tanstack-Query?](#-why-tanstack-query)
+  - [🤔 Why MongoDB?](#-why-mongodb)
+- [**🕹️ Features**](#-features)
+- [**🏔 Challenges**](#-challenges)
+  - [1. MongoDB로 데이터베이스 간 관계 설정 기능을 어떻게 구현할까?](#1-mongodb로-데이터베이스-간-관계-설정-기능을-어떻게-구현할까)
   - [2. 비전문가를 배려한 직관적인 데이터베이스툴 구현](#2-비전문가를-배려한-직관적인-데이터베이스툴-구현)
     - [2-1. 자연스러운 유저플로우를 위한 저장방식 고민](#2-1-자연스러운-유저플로우를-위한-저장방식-고민)
     - [2-2. 각 타입에 어울리는 태그를 다르게 적용하기](#2-2-각-타입에-어울리는-태그를-다르게-적용하기)
     - [2-3. 포탈마다 다른 쿼리결과를 렌더링하도록 구현](#2-3-포탈마다-다른-쿼리결과를-렌더링하도록-구현)
     - [2-4. 배경지식이 없더라도 쉽게 할 수 있는 관계설정](#2-4-배경지식이-없더라도-쉽게-할-수-있는-관계설정)
-- [**🔥 Issues**](#🔥-issues)
+- [**🔥 Issues**](#-issues)
   - [Portal의 값 갱신 이슈](#portal의-값-갱신-이슈)
   - [Header 와 SideBar 컴포넌트 간의 state 변경 이슈](#header-와-sidebar-컴포넌트-간의-state-변경-이슈)
-- [**🗓 Schedule**](#🗓-schedule)
-- [**👨‍👩‍👦 Memoir**](#👨‍👩‍👦-memoir)
+- [**🗓 Schedule**](#-schedule)
+- [**👨‍👩‍👦 Memoir**](#-memoir)
 
 <br>
 

--- a/src/apis/useDeleteDB.jsx
+++ b/src/apis/useDeleteDB.jsx
@@ -4,11 +4,9 @@ import { useSetAtom, useAtomValue } from "jotai";
 import fetchData from "../utils/axios";
 
 import {
-  databasesAtom,
   currentDBIdAtom,
   currentDBNameAtom,
   userAtom,
-  currentDocIndexAtom,
   showDeleteDBModalAtom,
 } from "../atoms/atoms";
 
@@ -18,11 +16,9 @@ function useDeleteDB() {
   const queryClient = useQueryClient();
 
   const { userId } = useAtomValue(userAtom);
-  const databases = useAtomValue(databasesAtom);
 
   const setCurrentDBId = useSetAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
-  const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
   const setShowDeleteDBModal = useSetAtom(showDeleteDBModalAtom);
 
   async function deleteDatabase(databaseId) {
@@ -36,10 +32,7 @@ function useDeleteDB() {
 
   const { mutate: fetchDeleteDB, isLoading } = useMutation(deleteDatabase, {
     onSuccess: result => {
-      if (databases.length === 1) {
-        setCurrentDocIndex(0);
-        setCurrentDBName("");
-      } else {
+      if (result.length) {
         setCurrentDBId(result[0]._id);
         setCurrentDBName(result[0].name);
       }

--- a/src/apis/useDeleteRelationship.jsx
+++ b/src/apis/useDeleteRelationship.jsx
@@ -35,7 +35,7 @@ function useDeleteRelationship() {
     {
       onSuccess: () => {
         queryClient.refetchQueries(["SingleDatabase", currentDBId]);
-        queryClient.refetchQueries(["Relationships", currentDBId]);
+        queryClient.refetchQueries(["ForeignDatabases", currentDBId]);
         setShowDeleteRelationshipModal(false);
       },
     },

--- a/src/apis/useGetAllDatabases.jsx
+++ b/src/apis/useGetAllDatabases.jsx
@@ -6,11 +6,11 @@ import { useAtom, useSetAtom, useAtomValue } from "jotai";
 import fetchData from "../utils/axios";
 
 import {
-  databasesAtom,
   currentDBIdAtom,
   currentDBNameAtom,
   isInitialAtom,
   userAtom,
+  currentDocIndexAtom,
 } from "../atoms/atoms";
 
 import Loading from "../components/shared/Loading";
@@ -21,9 +21,9 @@ function useGetAllDatabases() {
 
   const [isInitial, setIsInitial] = useAtom(isInitialAtom);
 
-  const setDatabases = useSetAtom(databasesAtom);
   const setCurrentDBId = useSetAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
+  const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
 
   async function getDatabaseList() {
     const response = await fetchData("GET", `users/${userId}/databases`);
@@ -44,11 +44,12 @@ function useGetAllDatabases() {
         }
 
         if (!result.length) {
+          setCurrentDocIndex(0);
+          setCurrentDBName("");
           navigate("/dashboard/nodatabase");
           return;
         }
 
-        setDatabases(result);
         navigate("/dashboard/listview");
       },
       refetchOnWindowFocus: false,

--- a/src/apis/useGetForeignDatabases.jsx
+++ b/src/apis/useGetForeignDatabases.jsx
@@ -22,7 +22,7 @@ function useGetForeignDatabases() {
   }
 
   const { data: foreignDatabases, isLoading } = useQuery(
-    ["ForeignDocuments", currentDBId],
+    ["ForeignDatabases", currentDBId],
     () => getRelationships(),
     {
       enabled:

--- a/src/apis/useGetForeignDatabases.jsx
+++ b/src/apis/useGetForeignDatabases.jsx
@@ -1,0 +1,42 @@
+/* eslint-disable prettier/prettier */
+import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+
+import { userAtom, currentDBIdAtom } from "../atoms/atoms";
+
+import fetchData from "../utils/axios";
+
+import Loading from "../components/shared/Loading";
+
+function useGetForeignDatabases() {
+  const { userId } = useAtomValue(userAtom);
+  const currentDBId = useAtomValue(currentDBIdAtom);
+
+  async function getRelationships() {
+    const response = await fetchData(
+      "GET",
+      `users/${userId}/databases/${currentDBId}/relationships`,
+    );
+
+    return response.data.foreignDatabases;
+  }
+
+  const { data: foreignDatabases, isLoading } = useQuery(
+    ["ForeignDocuments", currentDBId],
+    () => getRelationships(),
+    {
+      enabled:
+        !!userId &&
+        !!currentDBId,
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return { foreignDatabases };
+}
+
+export default useGetForeignDatabases;

--- a/src/apis/useGetForeignDocument.jsx
+++ b/src/apis/useGetForeignDocument.jsx
@@ -4,13 +4,7 @@ import { useAtomValue } from "jotai";
 
 import fetchData from "../utils/axios";
 
-import {
-  currentDocIndexAtom,
-  primaryFieldAtom,
-  userAtom,
-  currentDBIdAtom,
-  relationshipsDataAtom,
-} from "../atoms/atoms";
+import { currentDocIndexAtom, userAtom, currentDBIdAtom } from "../atoms/atoms";
 
 import Loading from "../components/shared/Loading";
 
@@ -19,14 +13,13 @@ function useGetForeignDocument(index, relationship, documents) {
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
-  const primaryField = useAtomValue(primaryFieldAtom);
-  const relationshipsData = useAtomValue(relationshipsDataAtom);
 
-  async function getForeignDocuments(relationshipsIndex) {
+  async function getForeignDocuments() {
+    const { primaryFieldName } = relationship;
     let queryValue = "";
 
     documents[currentDocIndex]?.fields.forEach(element => {
-      if (primaryField[relationshipsIndex] === element.fieldName) {
+      if (primaryFieldName === element.fieldName) {
         queryValue = element.fieldValue.trim();
       }
     });
@@ -53,7 +46,7 @@ function useGetForeignDocument(index, relationship, documents) {
         !!userId &&
         !!currentDBId &&
         currentDocIndex !== undefined &&
-        !!relationshipsData,
+        !!relationship,
       refetchOnWindowFocus: false,
     },
   );

--- a/src/apis/useGetSingleDatabase.jsx
+++ b/src/apis/useGetSingleDatabase.jsx
@@ -10,7 +10,6 @@ import {
   documentsIdsAtom,
   changedDocAtom,
   documentsDataAtom,
-  primaryFieldAtom,
   relationshipsDataAtom,
   addDocfieldsAtom,
 } from "../atoms/atoms";
@@ -24,7 +23,6 @@ function useGetSingleDatabase() {
   const setDocumentsIds = useSetAtom(documentsIdsAtom);
   const setChangedDoc = useSetAtom(changedDocAtom);
   const setDocumentsData = useSetAtom(documentsDataAtom);
-  const setPrimaryField = useSetAtom(primaryFieldAtom);
   const setRelationshipsData = useSetAtom(relationshipsDataAtom);
   const setAddDocFields = useSetAtom(addDocfieldsAtom);
 
@@ -66,12 +64,6 @@ function useGetSingleDatabase() {
 
         if (result.relationships?.length) {
           setRelationshipsData(result.relationships);
-
-          const primaryFieldsList = result.relationships.map(element => {
-            return element.primaryFieldName;
-          });
-
-          setPrimaryField(primaryFieldsList);
 
           return;
         }

--- a/src/apis/useGetSingleDatabase.jsx
+++ b/src/apis/useGetSingleDatabase.jsx
@@ -9,7 +9,7 @@ import {
   userAtom,
   documentsIdsAtom,
   changedDocAtom,
-  docDataAtom,
+  documentsDataAtom,
   primaryFieldAtom,
   relationshipsDataAtom,
   addDocfieldsAtom,
@@ -23,7 +23,7 @@ function useGetSingleDatabase() {
 
   const setDocumentsIds = useSetAtom(documentsIdsAtom);
   const setChangedDoc = useSetAtom(changedDocAtom);
-  const setDocData = useSetAtom(docDataAtom);
+  const setDocumentsData = useSetAtom(documentsDataAtom);
   const setPrimaryField = useSetAtom(primaryFieldAtom);
   const setRelationshipsData = useSetAtom(relationshipsDataAtom);
   const setAddDocFields = useSetAtom(addDocfieldsAtom);
@@ -60,7 +60,7 @@ function useGetSingleDatabase() {
         });
 
         setAddDocFields(fieldsWithEmptyValue);
-        setDocData(result.documents);
+        setDocumentsData(result.documents);
         setChangedDoc(docs);
         setDocumentsIds(documentsId);
 

--- a/src/apis/useGetSingleDatabase.jsx
+++ b/src/apis/useGetSingleDatabase.jsx
@@ -11,7 +11,7 @@ import {
   changedDocAtom,
   documentsDataAtom,
   relationshipsDataAtom,
-  addDocfieldsAtom,
+  addDocumentFieldsAtom,
 } from "../atoms/atoms";
 
 import Loading from "../components/shared/Loading";
@@ -24,7 +24,7 @@ function useGetSingleDatabase() {
   const setChangedDoc = useSetAtom(changedDocAtom);
   const setDocumentsData = useSetAtom(documentsDataAtom);
   const setRelationshipsData = useSetAtom(relationshipsDataAtom);
-  const setAddDocFields = useSetAtom(addDocfieldsAtom);
+  const setAddDocumentFields = useSetAtom(addDocumentFieldsAtom);
 
   async function getSingleDatabase() {
     const response = await fetchData(
@@ -57,7 +57,7 @@ function useGetSingleDatabase() {
           };
         });
 
-        setAddDocFields(fieldsWithEmptyValue);
+        setAddDocumentFields(fieldsWithEmptyValue);
         setDocumentsData(result.documents);
         setChangedDoc(docs);
         setDocumentsIds(documentsId);

--- a/src/apis/usePostDB.jsx
+++ b/src/apis/usePostDB.jsx
@@ -5,7 +5,7 @@ import fetchData from "../utils/axios";
 
 import {
   currentDBIdAtom,
-  isListViewAtom,
+  currentViewAtom,
   currentDBNameAtom,
   userAtom,
   showCreateDBModalAtom,
@@ -18,7 +18,7 @@ function usePostDB() {
   const navigate = useNavigate();
   const { userId } = useAtomValue(userAtom);
 
-  const setIsListView = useSetAtom(isListViewAtom);
+  const setCurrentView = useSetAtom(currentViewAtom);
   const setCurrentDBId = useSetAtom(currentDBIdAtom);
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setShowCreateDBModal = useSetAtom(showCreateDBModalAtom);
@@ -38,7 +38,7 @@ function usePostDB() {
     onSuccess: result => {
       setCurrentDBId(result.data.newDatabase._id);
       setCurrentDBName(result.data.newDatabase.name);
-      setIsListView(true);
+      setCurrentView("list");
       setCreateDBFields([
         {
           id: crypto.randomUUID(),

--- a/src/apis/usePostDocument.jsx
+++ b/src/apis/usePostDocument.jsx
@@ -8,8 +8,8 @@ import {
   currentDocIndexAtom,
   userAtom,
   showAddDocumentModalAtom,
-  addDocfieldsAtom,
   documentsIdsAtom,
+  addDocumentFieldsAtom,
 } from "../atoms/atoms";
 
 import Loading from "../components/shared/Loading";
@@ -18,7 +18,7 @@ function usePostDocument() {
   const queryClient = useQueryClient();
 
   const { userId } = useAtomValue(userAtom);
-  const fields = useAtomValue(addDocfieldsAtom);
+  const fields = useAtomValue(addDocumentFieldsAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
 
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);

--- a/src/apis/usePutSaveChangedData.jsx
+++ b/src/apis/usePutSaveChangedData.jsx
@@ -6,7 +6,7 @@ import {
   currentDBIdAtom,
   changedDocAtom,
   isListViewAtom,
-  docDataAtom,
+  documentsDataAtom,
   currentDocIndexAtom,
   relationshipsDataAtom,
 } from "../atoms/atoms";
@@ -19,7 +19,7 @@ function usePutSaveChangedData() {
   const currentDBId = useAtomValue(currentDBIdAtom);
   const changedDoc = useAtomValue(changedDocAtom);
   const isListview = useAtomValue(isListViewAtom);
-  const docData = useAtomValue(docDataAtom);
+  const documentsData = useAtomValue(documentsDataAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const relationshipsData = useAtomValue(relationshipsDataAtom);
 
@@ -36,8 +36,8 @@ function usePutSaveChangedData() {
 
     await fetchData(
       "PUT",
-      `/users/${userId}/databases/${currentDBId}/documents/${docData[currentDocIndex]._id}`,
-      { fields: docData[currentDocIndex].fields },
+      `/users/${userId}/databases/${currentDBId}/documents/${documentsData[currentDocIndex]._id}`,
+      { fields: documentsData[currentDocIndex].fields },
     );
 
     if (relationshipsData?.length) {

--- a/src/apis/usePutSaveChangedData.jsx
+++ b/src/apis/usePutSaveChangedData.jsx
@@ -5,7 +5,7 @@ import {
   userAtom,
   currentDBIdAtom,
   changedDocAtom,
-  isListViewAtom,
+  currentViewAtom,
   documentsDataAtom,
   currentDocIndexAtom,
   relationshipsDataAtom,
@@ -18,13 +18,13 @@ function usePutSaveChangedData() {
   const { userId } = useAtomValue(userAtom);
   const currentDBId = useAtomValue(currentDBIdAtom);
   const changedDoc = useAtomValue(changedDocAtom);
-  const isListview = useAtomValue(isListViewAtom);
+  const currentView = useAtomValue(currentViewAtom);
   const documentsData = useAtomValue(documentsDataAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
   const relationshipsData = useAtomValue(relationshipsDataAtom);
 
   async function handleClickSave() {
-    if (isListview) {
+    if (currentView === "list") {
       await fetchData(
         "PUT",
         `/users/${userId}/databases/${currentDBId}/documents`,

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -6,17 +6,16 @@ export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);
 
-export const isEditModeAtom = atom(false);
-export const isListViewAtom = atom(true);
-export const isRelationshipAtom = atom(false);
-
-export const relationshipsDataAtom = atom(null);
 export const documentsIdsAtom = atom([]);
+export const isEditModeAtom = atom(false);
+export const currentViewAtom = atom("list");
+
+export const documentsDataAtom = atom([]);
+export const relationshipsDataAtom = atom(null);
 
 export const isInitialAtom = atom(true);
 export const changedDocAtom = atom([]);
 
-export const documentsDataAtom = atom([]);
 export const draggingElementAtom = atom(null);
 export const elementScaleAtom = atom([]);
 

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -48,4 +48,3 @@ export const relationDataAtom = atom({
   foreignFieldsToDisplay: [],
   foreignDb: null,
 });
-export const targetDatabasesAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -17,7 +17,6 @@ export const isInitialAtom = atom(true);
 export const changedDocAtom = atom([]);
 
 export const documentsDataAtom = atom([]);
-export const primaryFieldAtom = atom(null);
 export const draggingElementAtom = atom(null);
 export const elementScaleAtom = atom([]);
 

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
 
+// user
 export const userAtom = atom("");
 
 export const currentDBIdAtom = atom("");
@@ -29,7 +30,7 @@ export const showDeleteRelationshipModalAtom = atom(false);
 export const deleteTargetRelationshipAtom = atom(null);
 export const isLastDocumentAtom = atom(false);
 
-export const addDocfieldsAtom = atom([]);
+export const addDocumentFieldsAtom = atom([]);
 export const createDBFieldsAtom = atom([
   {
     id: crypto.randomUUID(),
@@ -38,6 +39,7 @@ export const createDBFieldsAtom = atom([
   },
 ]);
 
+// relationshipModal
 export const relationshipStepAtom = atom("start");
 export const relationDataAtom = atom({
   primaryFieldName: "",

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -16,7 +16,7 @@ export const documentsIdsAtom = atom([]);
 export const isInitialAtom = atom(true);
 export const changedDocAtom = atom([]);
 
-export const docDataAtom = atom([]);
+export const documentsDataAtom = atom([]);
 export const primaryFieldAtom = atom(null);
 export const draggingElementAtom = atom(null);
 export const elementScaleAtom = atom([]);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -2,8 +2,6 @@ import { atom } from "jotai";
 
 export const userAtom = atom("");
 
-export const databasesAtom = atom([]);
-
 export const currentDBIdAtom = atom("");
 export const currentDBNameAtom = atom("");
 export const currentDocIndexAtom = atom(0);

--- a/src/atoms/atoms.js
+++ b/src/atoms/atoms.js
@@ -39,7 +39,6 @@ export const createDBFieldsAtom = atom([
   },
 ]);
 
-export const relationshipsAtom = atom([]);
 export const relationshipStepAtom = atom("start");
 export const relationDataAtom = atom({
   primaryFieldName: "",

--- a/src/components/HeaderItems/RelationshipButton.jsx
+++ b/src/components/HeaderItems/RelationshipButton.jsx
@@ -1,16 +1,16 @@
-import { useAtom, useAtomValue } from "jotai";
+import { useSetAtom, useAtomValue } from "jotai";
 import { useNavigate } from "react-router-dom";
 
-import { isEditModeAtom, isRelationshipAtom } from "../../atoms/atoms";
+import { isEditModeAtom, currentViewAtom } from "../../atoms/atoms";
 import Button from "../shared/Button";
 
 function RelationshipButton() {
   const navigate = useNavigate();
-  const [isRelationship, setIsRelationship] = useAtom(isRelationshipAtom);
+  const setCurrentView = useSetAtom(currentViewAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
   function clickHandleRelationship() {
-    setIsRelationship(true);
+    setCurrentView("relationship");
     navigate("/dashboard/relationship");
   }
 
@@ -26,7 +26,7 @@ function RelationshipButton() {
         src="/assets/relation_icon.svg"
         alt="relation icon"
       />
-      <span className="w-full">{isRelationship ? "Back" : "Relationship"}</span>
+      <span className="w-full">Relationship</span>
     </Button>
   );
 }

--- a/src/components/HeaderItems/SaveButton.jsx
+++ b/src/components/HeaderItems/SaveButton.jsx
@@ -1,19 +1,19 @@
 import { useAtom, useAtomValue } from "jotai";
 
-import { isEditModeAtom, isRelationshipAtom } from "../../atoms/atoms";
+import { isEditModeAtom, currentViewAtom } from "../../atoms/atoms";
 import usePutSaveChangedData from "../../apis/usePutSaveChangedData";
 
 import Button from "../shared/Button";
 
 function SaveButton() {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
-  const isRelationship = useAtomValue(isRelationshipAtom);
+  const currentView = useAtomValue(currentViewAtom);
   const fetchSaveChangedData = usePutSaveChangedData();
 
   return (
     <div
       className={`flex w-20 justify-center items-center
-    ${isRelationship && "hidden"}`}
+    ${currentView === "relationship" && "hidden"}`}
     >
       <Button
         className={`w-20 h-8 rounded-md bg-white

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -21,14 +21,15 @@ function SwitchViewButtons() {
     navigate("/dashboard/detailview");
   }
 
+  console.log(currentView);
+
   return (
     <div className="flex">
       <Button
         className={`flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md
-        ${currentView === "list" && isEditMode && "bg-dark-grey"}
-        ${currentView === "list" && !isEditMode && "bg-yellow"}
-        ${currentView !== "list" && isEditMode && "bg-dark-grey"}
-        ${currentView !== "list" && !isEditMode && "bg-white"}`}
+        ${!isEditMode && currentView === "list" && "bg-yellow"}
+        ${!isEditMode && currentView !== "list" && "bg-white"}
+        ${isEditMode && "bg-dark-grey"}`}
         onClick={switchToListView}
         disabled={isEditMode}
       >
@@ -37,10 +38,9 @@ function SwitchViewButtons() {
       </Button>
       <Button
         className={`flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md
-        ${currentView !== "list" && isEditMode && "bg-dark-grey"}
-        ${currentView !== "list" && !isEditMode && "bg-yellow"}
-        ${currentView === "list" && isEditMode && "bg-dark-grey"}
-        ${currentView === "list" && !isEditMode && "bg-white"}`}
+        ${!isEditMode && currentView === "detail" && "bg-yellow"}
+        ${!isEditMode && currentView !== "detail" && "bg-white"}
+        ${isEditMode && "bg-dark-grey"}`}
         onClick={switchToDetailView}
         disabled={isEditMode}
       >

--- a/src/components/HeaderItems/SwitchViewButtons.jsx
+++ b/src/components/HeaderItems/SwitchViewButtons.jsx
@@ -1,23 +1,23 @@
 import { useNavigate } from "react-router-dom";
 import { useAtom, useAtomValue } from "jotai";
 
-import { isListViewAtom, isEditModeAtom } from "../../atoms/atoms";
+import { currentViewAtom, isEditModeAtom } from "../../atoms/atoms";
 
 import Button from "../shared/Button";
 
 function SwitchViewButtons() {
   const navigate = useNavigate();
 
-  const [isListView, setIsListView] = useAtom(isListViewAtom);
+  const [currentView, setCurrentView] = useAtom(currentViewAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
   function switchToListView() {
-    setIsListView(true);
+    setCurrentView("list");
     navigate("/dashboard/listview");
   }
 
   function switchToDetailView() {
-    setIsListView(false);
+    setCurrentView("detail");
     navigate("/dashboard/detailview");
   }
 
@@ -25,10 +25,10 @@ function SwitchViewButtons() {
     <div className="flex">
       <Button
         className={`flex flex-row items-center w-[120px] h-9 mr-1 p-2 rounded-md
-        ${isListView && isEditMode && "bg-dark-grey"}
-        ${isListView && !isEditMode && "bg-yellow"}
-        ${!isListView && isEditMode && "bg-dark-grey"}
-        ${!isListView && !isEditMode && "bg-white"}`}
+        ${currentView === "list" && isEditMode && "bg-dark-grey"}
+        ${currentView === "list" && !isEditMode && "bg-yellow"}
+        ${currentView !== "list" && isEditMode && "bg-dark-grey"}
+        ${currentView !== "list" && !isEditMode && "bg-white"}`}
         onClick={switchToListView}
         disabled={isEditMode}
       >
@@ -37,10 +37,10 @@ function SwitchViewButtons() {
       </Button>
       <Button
         className={`flex flex-row items-center w-[130px] h-9 mr-1 p-2 rounded-md
-        ${!isListView && isEditMode && "bg-dark-grey"}
-        ${!isListView && !isEditMode && "bg-yellow"}
-        ${isListView && isEditMode && "bg-dark-grey"}
-        ${isListView && !isEditMode && "bg-white"}`}
+        ${currentView !== "list" && isEditMode && "bg-dark-grey"}
+        ${currentView !== "list" && !isEditMode && "bg-yellow"}
+        ${currentView === "list" && isEditMode && "bg-dark-grey"}
+        ${currentView === "list" && !isEditMode && "bg-white"}`}
         onClick={switchToDetailView}
         disabled={isEditMode}
       >

--- a/src/components/HeaderItems/Toolbar.jsx
+++ b/src/components/HeaderItems/Toolbar.jsx
@@ -1,11 +1,7 @@
 import { useNavigate } from "react-router-dom";
-import { useAtom, useSetAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 
-import {
-  isListViewAtom,
-  isEditModeAtom,
-  isRelationshipAtom,
-} from "../../atoms/atoms";
+import { currentViewAtom, isEditModeAtom } from "../../atoms/atoms";
 
 import RelationshipButton from "./RelationshipButton";
 import DocHandlerButtons from "./DocHandlerButtons";
@@ -15,13 +11,11 @@ import Button from "../shared/Button";
 function Toolbar() {
   const navigate = useNavigate();
 
-  const [isRelationship, setIsRelationship] = useAtom(isRelationshipAtom);
-  const setIsListView = useSetAtom(isListViewAtom);
+  const [currentView, setCurrentView] = useAtom(currentViewAtom);
   const isEditMode = useAtomValue(isEditModeAtom);
 
   function clickHandelBackButton() {
-    setIsRelationship(false);
-    setIsListView(true);
+    setCurrentView("list");
     navigate("/dashboard/listview");
   }
 
@@ -29,7 +23,7 @@ function Toolbar() {
     <>
       <Button
         className={`flex flex-row justify-center items-center w-[100px] h-9 p-2 rounded-md bg-white
-        ${!isRelationship && "hidden"}`}
+        ${currentView !== "relationship" && "hidden"}`}
         onClick={clickHandelBackButton}
         disabled={isEditMode}
       >
@@ -37,7 +31,7 @@ function Toolbar() {
       </Button>
       <div
         className={`flex justify-between items-center w-full h-full mr-3 bg-black-bg
-        ${isRelationship && "hidden"}`}
+        ${currentView === "relationship" && "hidden"}`}
       >
         <RelationshipButton />
         <DocHandlerButtons />

--- a/src/components/Modals/AddNewDocument/AddDocInputList.jsx
+++ b/src/components/Modals/AddNewDocument/AddDocInputList.jsx
@@ -2,27 +2,29 @@ import { useAtom } from "jotai";
 
 import getTodaysDate from "../../../utils/getTodaysDate";
 
-import { addDocfieldsAtom } from "../../../atoms/atoms";
+import { addDocumentFieldsAtom } from "../../../atoms/atoms";
 
 import InputWrapper from "../SharedItems/InputWrapper";
 
 function AddDocInputList() {
-  const [addDocfields, setAddDocFields] = useAtom(addDocfieldsAtom);
+  const [addDocumentFields, setAddDocumentFields] = useAtom(
+    addDocumentFieldsAtom,
+  );
 
   function adjustTextareaHeight(event) {
     event.target.style.height = `${event.target.scrollHeight}px`;
   }
 
   function updateFieldValue(index, event) {
-    const newAddDocFields = [...addDocfields];
+    const newAddDocumentFields = [...addDocumentFields];
 
-    newAddDocFields[index].fieldValue = event.target.value;
+    newAddDocumentFields[index].fieldValue = event.target.value;
 
-    setAddDocFields(newAddDocFields);
+    setAddDocumentFields(newAddDocumentFields);
     adjustTextareaHeight(event);
   }
 
-  return addDocfields.map((element, index) => {
+  return addDocumentFields.map((element, index) => {
     return (
       <div key={element._id} className="flex w-[500px]">
         <span

--- a/src/components/Modals/Relationship/Done.jsx
+++ b/src/components/Modals/Relationship/Done.jsx
@@ -32,7 +32,8 @@ function Done() {
         className="w-20 h-8 mt-5 rounded-md bg-black-bg text-white hover:bg-dark-grey"
         onClick={() => {
           queryClient.refetchQueries(["SingleDatase", currentDBId]);
-          queryClient.refetchQueries(["Relationships", currentDBId]);
+          queryClient.refetchQueries(["ForeignDatabases", currentDBId]);
+          queryClient.refetchQueries(["ForeignDocuments", currentDBId]);
           setShowRelationshipModal(false);
           setRelationshipStep("start");
         }}

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,14 +1,7 @@
 import { useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 
-import {
-  currentDBIdAtom,
-  relationshipStepAtom,
-  relationDataAtom,
-  targetDatabasesAtom,
-} from "../../../atoms/atoms";
-
-import useGetAllDatabases from "../../../apis/useGetAllDatabases";
+import { relationshipStepAtom, relationDataAtom } from "../../../atoms/atoms";
 
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";
@@ -19,19 +12,9 @@ import DatabasesWizard from "./WizardItems/DatabasesWizard";
 function StepOne() {
   const [isNotSelected, setIsNotSelected] = useState(false);
 
-  const currentDBId = useAtomValue(currentDBIdAtom);
   const relationData = useAtomValue(relationDataAtom);
 
   const setRelationshipStep = useSetAtom(relationshipStepAtom);
-  const setTargetDatabases = useSetAtom(targetDatabasesAtom);
-
-  const { databases } = useGetAllDatabases();
-
-  const filteredDbs = databases.filter(
-    database => database._id !== currentDBId,
-  );
-
-  setTargetDatabases(filteredDbs);
 
   function handleNextClick() {
     if (!relationData.foreignDbId) {

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 
+import useGetAllDatabases from "../../../apis/useGetAllDatabases";
+
 import {
-  databasesAtom,
   currentDBIdAtom,
   relationshipStepAtom,
   relationDataAtom,
@@ -20,10 +21,11 @@ function StepOne() {
 
   const currentDBId = useAtomValue(currentDBIdAtom);
   const relationData = useAtomValue(relationDataAtom);
-  const databases = useAtomValue(databasesAtom);
 
   const setRelationshipStep = useSetAtom(relationshipStepAtom);
   const setTargetDatabases = useSetAtom(targetDatabasesAtom);
+
+  const { databases } = useGetAllDatabases();
 
   const filteredDbs = databases.filter(
     database => database._id !== currentDBId,

--- a/src/components/Modals/Relationship/StepOne.jsx
+++ b/src/components/Modals/Relationship/StepOne.jsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 
-import useGetAllDatabases from "../../../apis/useGetAllDatabases";
-
 import {
   currentDBIdAtom,
   relationshipStepAtom,
   relationDataAtom,
   targetDatabasesAtom,
 } from "../../../atoms/atoms";
+
+import useGetAllDatabases from "../../../apis/useGetAllDatabases";
 
 import Content from "../SharedItems/Content";
 import Title from "../SharedItems/Title";

--- a/src/components/Modals/Relationship/StepTwo.jsx
+++ b/src/components/Modals/Relationship/StepTwo.jsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import {
-  databasesAtom,
   currentDBIdAtom,
   relationshipStepAtom,
   relationDataAtom,
 } from "../../../atoms/atoms";
+
+import useGetAllDatabases from "../../../apis/useGetAllDatabases";
 
 import Title from "../SharedItems/Title";
 import Button from "../../shared/Button";
@@ -20,9 +21,10 @@ function StepTwo() {
   const [relationData, setRelationData] = useAtom(relationDataAtom);
 
   const currentDBId = useAtomValue(currentDBIdAtom);
-  const databases = useAtomValue(databasesAtom);
 
   const setRelationshipStep = useSetAtom(relationshipStepAtom);
+
+  const { databases } = useGetAllDatabases();
 
   const stepTwoSetUpData = {};
 

--- a/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
+++ b/src/components/Modals/Relationship/WizardItems/DatabasesWizard.jsx
@@ -5,15 +5,23 @@ import { useAtom, useAtomValue } from "jotai";
 
 import {
   relationDataAtom,
-  targetDatabasesAtom,
   currentDBNameAtom,
+  currentDBIdAtom,
 } from "../../../../atoms/atoms";
+
+import useGetAllDatabases from "../../../../apis/useGetAllDatabases";
 
 function DatabasesWizard() {
   const [isSelected, setIsSelected] = useState("");
   const [relationData, setRelationData] = useAtom(relationDataAtom);
-  const targetDatabases = useAtomValue(targetDatabasesAtom);
+  const currentDBId = useAtomValue(currentDBIdAtom);
   const currentDBName = useAtomValue(currentDBNameAtom);
+
+  const { databases } = useGetAllDatabases();
+
+  const otherDatabases = databases?.filter(
+    database => database._id !== currentDBId,
+  );
 
   function handleDatabaseClick(id) {
     setIsSelected(id);
@@ -32,11 +40,11 @@ function DatabasesWizard() {
       <div className="border border-blue border-dashed h-16"></div>
       <div className="flex flex-col items-center w-full max-h-[190px] border-2 rounded-lg overflow-y-scroll">
         <ul className="w-full h-auto text-center">
-          {targetDatabases.map((database, index) => (
+          {otherDatabases.map((database, index) => (
             <li
               className={`w-full py-1 border-b-2 border-grey
               ${isSelected === database._id ? "bg-yellow" : ""}
-              ${index === targetDatabases.length - 1 ? "border-b-0" : ""}`}
+              ${index === otherDatabases.length - 1 ? "border-b-0" : ""}`}
               key={database._id}
               onClick={() => handleDatabaseClick(database._id)}
             >

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -6,12 +6,11 @@ import {
   currentDBNameAtom,
   currentDocIndexAtom,
   isEditModeAtom,
-  isRelationshipAtom,
-  relationshipsDataAtom,
   userAtom,
   showCreateDBModalAtom,
   showDeleteDBModalAtom,
   deleteTargetDBIdAtom,
+  currentViewAtom,
 } from "../atoms/atoms";
 
 import useGetAllDatabases from "../apis/useGetAllDatabases";
@@ -23,6 +22,7 @@ import DeleteDBModal from "./Modals/DeleteDatabase/DeleteDBModal";
 function Sidebar() {
   const queryClient = useQueryClient();
   const { username } = useAtomValue(userAtom);
+  const currentView = useAtomValue(currentViewAtom);
   const [currentDBId, setCurrentDBId] = useAtom(currentDBIdAtom);
   const [showDeleteDBModal, setShowDeleteDBModal] = useAtom(
     showDeleteDBModalAtom,
@@ -34,10 +34,8 @@ function Sidebar() {
 
   const setCurrentDBName = useSetAtom(currentDBNameAtom);
   const setCurrentDocIndex = useSetAtom(currentDocIndexAtom);
-  const setRelationshipsData = useSetAtom(relationshipsDataAtom);
 
   const isEditMode = useAtomValue(isEditModeAtom);
-  const isRelationship = useAtomValue(isRelationshipAtom);
 
   const { databases } = useGetAllDatabases();
 
@@ -59,7 +57,6 @@ function Sidebar() {
       setCurrentDocIndex(0);
       setCurrentDBId(clickedDBId);
       setCurrentDBName(clickedDB);
-      setRelationshipsData(null);
 
       queryClient.refetchQueries(["SingleDatabase", clickedDBId]);
     }
@@ -115,7 +112,7 @@ function Sidebar() {
         <Button
           className={`flex justify-center w-48 text-sm items-center rounded-full text-white
           ${
-            isEditMode || isRelationship
+            isEditMode || currentView === "list"
               ? "hidden"
               : "bg-black-bg hover:bg-dark-grey"
           }`}

--- a/src/components/contents/DetailViewItems/DetailView.jsx
+++ b/src/components/contents/DetailViewItems/DetailView.jsx
@@ -5,7 +5,7 @@ import {
   currentDocIndexAtom,
   isEditModeAtom,
   relationshipsDataAtom,
-  docDataAtom,
+  documentsDataAtom,
   draggingElementAtom,
   elementScaleAtom,
 } from "../../../atoms/atoms";
@@ -24,7 +24,7 @@ function DetailView() {
 
   const elementScale = useAtomValue(elementScaleAtom);
 
-  const [docData, setDocData] = useAtom(docDataAtom);
+  const [documentsData, setDocumentsData] = useAtom(documentsDataAtom);
   const [draggingElement, setDraggingElement] = useAtom(draggingElementAtom);
   const [relationshipsData, setRelationshipsData] = useAtom(
     relationshipsDataAtom,
@@ -48,8 +48,8 @@ function DetailView() {
       moveField(
         canvasRect,
         event,
-        docData,
-        setDocData,
+        documentsData,
+        setDocumentsData,
         currentDocIndex,
         draggingElement,
         elementScale,

--- a/src/components/contents/DetailViewItems/FieldFooter.jsx
+++ b/src/components/contents/DetailViewItems/FieldFooter.jsx
@@ -1,19 +1,19 @@
 import { useAtom, useAtomValue } from "jotai";
 
-import { docDataAtom, currentDocIndexAtom } from "../../../atoms/atoms";
+import { documentsDataAtom, currentDocIndexAtom } from "../../../atoms/atoms";
 
 import Button from "../../shared/Button";
 
 function FieldFooter({ index }) {
-  const [docData, setDocData] = useAtom(docDataAtom);
+  const [documentsData, setDocumentsData] = useAtom(documentsDataAtom);
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
 
   function updateFieldRows(fieldIndex, value) {
-    const newDocData = [...docData];
+    const newDocData = [...documentsData];
 
     newDocData[currentDocIndex].fields[fieldIndex].rows = value;
 
-    setDocData(newDocData);
+    setDocumentsData(newDocData);
   }
 
   return (

--- a/src/components/contents/DetailViewItems/FieldList.jsx
+++ b/src/components/contents/DetailViewItems/FieldList.jsx
@@ -2,7 +2,7 @@ import { useAtom, useSetAtom, useAtomValue } from "jotai";
 
 import {
   isEditModeAtom,
-  docDataAtom,
+  documentsDataAtom,
   currentDocIndexAtom,
   draggingElementAtom,
   elementScaleAtom,
@@ -16,12 +16,11 @@ import FieldFooter from "./FieldFooter";
 function FieldList() {
   const [isEditMode, setIsEditMode] = useAtom(isEditModeAtom);
   const [draggingElement, setDraggingElement] = useAtom(draggingElementAtom);
-  const [docData, setDocData] = useAtom(docDataAtom);
+  const [documentsData, setDocumentsData] = useAtom(documentsDataAtom);
 
   const setElementScale = useSetAtom(elementScaleAtom);
 
   const currentDocIndex = useAtomValue(currentDocIndexAtom);
-  const document = docData[currentDocIndex];
 
   function updateDateModified(newDocData, fields) {
     const dateModifiedFieldIndex = fields.findIndex(
@@ -35,15 +34,19 @@ function FieldList() {
   }
 
   function updateFieldValue(index, event) {
-    const newDocData = [...docData];
+    const newDocumentsData = [...documentsData];
 
-    newDocData[currentDocIndex].fields[index].fieldValue = event.target.value;
+    newDocumentsData[currentDocIndex].fields[index].fieldValue =
+      event.target.value;
 
-    updateDateModified(newDocData, newDocData[currentDocIndex].fields);
-    setDocData(newDocData);
+    updateDateModified(
+      newDocumentsData,
+      newDocumentsData[currentDocIndex].fields,
+    );
+    setDocumentsData(newDocumentsData);
   }
 
-  return document?.fields.map((element, index) => {
+  return documentsData[currentDocIndex]?.fields.map((element, index) => {
     return (
       <div
         key={element.fieldName}

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -26,8 +26,8 @@ function DatabaseFields({
   );
   const [fieldNames, setFieldNames] = useState([]);
   const [updatedFields, setUpdatedFields] = useState(() => {
-    if (currentDBId === databaseId) {
-      const primaryFieldNames = singleDatabase?.relationships.map(
+    if (currentDBId === databaseId && singleDatabase?.relationships) {
+      const primaryFieldNames = singleDatabase.relationships.map(
         relation => relation.primaryFieldName,
       );
       const updatedFieldsCopy = fields.filter(

--- a/src/components/contents/RelationshipItems/DatabaseFields.jsx
+++ b/src/components/contents/RelationshipItems/DatabaseFields.jsx
@@ -4,7 +4,6 @@ import { useAtomValue, useAtom, useSetAtom } from "jotai";
 
 import {
   currentDBIdAtom,
-  relationshipsAtom,
   deleteTargetRelationshipAtom,
   showDeleteRelationshipModalAtom,
 } from "../../../atoms/atoms";
@@ -12,9 +11,14 @@ import {
 import Button from "../../shared/Button";
 import DeleteRelationshipModal from "../../Modals/DeleteRelationship/DeleteRelationshipModal";
 
-function DatabaseFields({ fields, databaseName, databaseId, dbIndex }) {
+function DatabaseFields({
+  singleDatabase,
+  fields,
+  databaseName,
+  databaseId,
+  dbIndex,
+}) {
   const currentDBId = useAtomValue(currentDBIdAtom);
-  const relationships = useAtomValue(relationshipsAtom);
 
   const setDeleteTargetRelationship = useSetAtom(deleteTargetRelationshipAtom);
   const [showDeleteRelationshipModal, setShowDeleteRelationshipModal] = useAtom(
@@ -23,7 +27,7 @@ function DatabaseFields({ fields, databaseName, databaseId, dbIndex }) {
   const [fieldNames, setFieldNames] = useState([]);
   const [updatedFields, setUpdatedFields] = useState(() => {
     if (currentDBId === databaseId) {
-      const primaryFieldNames = relationships.map(
+      const primaryFieldNames = singleDatabase?.relationships.map(
         relation => relation.primaryFieldName,
       );
       const updatedFieldsCopy = fields.filter(
@@ -33,15 +37,15 @@ function DatabaseFields({ fields, databaseName, databaseId, dbIndex }) {
         primaryFieldNames.includes(field.fieldName),
       );
 
-      primaryField.forEach(fieldNmae => updatedFieldsCopy.unshift(fieldNmae));
+      primaryField.forEach(fieldName => updatedFieldsCopy.unshift(fieldName));
 
       setFieldNames(primaryFieldNames);
 
       return updatedFieldsCopy;
     }
 
-    const relation = relationships.find(
-      item => item.foreignDbId === databaseId,
+    const relation = singleDatabase?.relationships.find(
+      relationship => relationship.foreignDbId === databaseId,
     );
     const foreignFieldName = relation?.foreignFieldName;
     const foreignDbId = relation?.foreignDbId;

--- a/src/components/contents/RelationshipItems/Relationship.jsx
+++ b/src/components/contents/RelationshipItems/Relationship.jsx
@@ -23,31 +23,42 @@ function Relationship() {
   const { foreignDatabases } = useGetForeignDatabases();
 
   // eslint-disable-next-line consistent-return
-  function sortDatabases(array) {
-    const { length } = array;
-    const primaryDbIndex = array.findIndex(item => item._id === currentDBId);
+  function sortDatabases(baseAndTargetDBs) {
+    const { length } = baseAndTargetDBs;
+    const primaryDbIndex = baseAndTargetDBs.findIndex(
+      item => item._id === currentDBId,
+    );
 
     if (length === 1) {
-      return array;
+      return baseAndTargetDBs;
     }
+
     if (length === 2) {
-      const newDatabases = primaryDbIndex === 0 ? [array[0], array[1]] : array;
+      const newBaseAndTargetDBs =
+        primaryDbIndex === 0
+          ? [baseAndTargetDBs[0], baseAndTargetDBs[1]]
+          : baseAndTargetDBs;
 
-      return newDatabases;
+      return newBaseAndTargetDBs;
     }
-    if (length === 3) {
-      const newDatabases = [array[2], array[primaryDbIndex], array[1]];
 
-      return newDatabases;
+    if (length === 3) {
+      const newBaseAndTargetDBs = [
+        baseAndTargetDBs[2],
+        baseAndTargetDBs[primaryDbIndex],
+        baseAndTargetDBs[1],
+      ];
+
+      return newBaseAndTargetDBs;
     }
   }
 
   // eslint-disable-next-line consistent-return
   useMemo(() => {
     if (singleDatabase && foreignDatabases) {
-      const newDb = [singleDatabase, ...foreignDatabases];
+      const baseAndTargetDBs = [singleDatabase, ...foreignDatabases];
 
-      setSortedDatabases(sortDatabases(newDb));
+      setSortedDatabases(sortDatabases(baseAndTargetDBs));
     }
   }, [singleDatabase, foreignDatabases]);
 

--- a/src/utils/moveField.js
+++ b/src/utils/moveField.js
@@ -3,8 +3,8 @@ import CONSTANT from "../constants/constant";
 function moveField(
   canvasRect,
   event,
-  docData,
-  setDocData,
+  documentsData,
+  setDocumentsData,
   currentDocIndex,
   draggingElement,
   elementScale,
@@ -20,7 +20,7 @@ function moveField(
   const elementWidth = 370;
   const elementHeight = elementScale[1] + 40;
 
-  const newDocData = [...docData];
+  const newDocumentsData = [...documentsData];
 
   const isAboveCanvas = currentYBasedOnCanvasArea < 0;
   const isLeftOfCanvas = currentXBasedOnCanvasArea < 0;
@@ -30,9 +30,11 @@ function moveField(
     currentYBasedOnCanvasArea > CONSTANT.CANVAS_H - elementHeight;
 
   function setCoordinates(x, y) {
-    newDocData[currentDocIndex].fields[draggedElementIndex].xCoordinate = x;
-    newDocData[currentDocIndex].fields[draggedElementIndex].yCoordinate = y;
-    setDocData(newDocData);
+    newDocumentsData[currentDocIndex].fields[draggedElementIndex].xCoordinate =
+      x;
+    newDocumentsData[currentDocIndex].fields[draggedElementIndex].yCoordinate =
+      y;
+    setDocumentsData(newDocumentsData);
   }
 
   if (isAboveCanvas && isLeftOfCanvas) {


### PR DESCRIPTION
### description

- 새로운 커스텀훅 useGetForeignDatabases를 작성하였습니다. 반환하는 값이 Target DB인 관계로 여기에 맞추어 쿼리키를 정확한 이름인 "ForeignDatabases"로 고쳐주었습니다.

- useGetForeignDatabases이 생겨남에 따라 Relationship 컴포넌트 내부의 useQuery를 커스텀훅으로 변경해주었습니다.

- 서버스테이트의 복제값을 담는 atom들의 역할을 관찰하고, 불필요한 경우 atom을 제거해 정리하였습니다. 
- (!) documentsDataAtom 와 relationshipsDataAtom은 유저가 수정을 가할 시 변경된 내용을 저장해줄 컨테이너임을 확인, 제거하지 않았습니다. 참고 부탁드립니다.
1. documentsDataAtom: 도큐먼트 내용 수정시 이용됨
2. relationshipsDataAtom: 포탈을 옮기는 등 수정시 이용됨

- isRelationship의 네이밍 모호함, 현재페이지에 관하여 state가 불필요하게 두개까지 필요한 점, 그리고 앞으로의 앱의 확장성을 고려하여 isListView와 isRelationship을 currentView로 통합하였습니다. 앞으로 페이지가 늘어나더라도 state가 늘지 않아 유지보수성측면에서 나을것으로 생각됩니다.

- readme의 목차링크를 최종수정.

- 머지 후에는 이어서 store 분할 작업이 진행될 예정입니다.

- 꼼꼼히 테스트해본 후 업로드하고 있습니다만 만약 문제가 발견되면 말씀해주세요. 감사합니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [X] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [X] 코드 컨벤션을 모두 지켰습니다.
- [X] 적절한 라벨이 있습니다.
- [X] assignee가 있습니다.
